### PR TITLE
test: sequence generation should throw not supported exception

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -264,6 +264,16 @@ CONSTRAINT Chk_Title_Length_Equal CHECK (CHARACTER_LENGTH(Title) > 0),
         }
 
         [Fact]
+        public virtual void DropSequenceOperation()
+        {
+            Assert.Throws<NotSupportedException>(() => Generate(
+                new DropSequenceOperation
+                {
+                    Name = "SpannerkHiLoSequence"
+                }));
+        }
+
+        [Fact]
         public virtual void RenameSequenceOperation()
         {
             Assert.Throws<NotSupportedException>(() => Generate(

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -338,5 +338,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             throw new NotSupportedException($"Cloud Spanner doesn't have a sequence generation feature.");
         }
+
+        protected override void Generate(DropSequenceOperation operation, IModel model, MigrationCommandListBuilder builder)
+        {
+            throw new NotSupportedException($"Cloud Spanner doesn't have a sequence generation feature.");
+        }
     }
 }


### PR DESCRIPTION
As currently Cloud Spanner doesn't have a sequence generation feature it should throw an exception.