### PR TITLE
test: unflake AbortedTransactionsTests

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MockSpannerServer.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MockSpannerServer.cs
@@ -292,11 +292,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             );
         }
 
-        public void AddOrUpdateExecutionTime(string method, string sql, ExecutionTime executionTime)
+        public void AddOrUpdateExecutionTime(string method, ExecutionTime executionTime)
         {
-            _executionTimes.AddOrUpdate(method + sql,
+            _executionTimes.AddOrUpdate(method,
                 executionTime,
-                (string methodAndSql, ExecutionTime existing) => executionTime
+                (string method, ExecutionTime existing) => executionTime
             );
         }
 
@@ -544,7 +544,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public override async Task ExecuteStreamingSql(ExecuteSqlRequest request, IServerStreamWriter<PartialResultSet> responseStream, ServerCallContext context)
         {
             _requests.Enqueue(request);
-            _executionTimes.TryGetValue(nameof(ExecuteStreamingSql) + request.Sql, out ExecutionTime executionTime);
+            _executionTimes.TryGetValue(nameof(ExecuteStreamingSql), out ExecutionTime executionTime);
             Session session = TryFindSession(request.SessionAsSessionName);
             Transaction tx = FindOrBeginTransaction(request.SessionAsSessionName, request.Transaction);
             if (_results.TryGetValue(request.Sql, out StatementResult result))

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/SpannerMockServerFixture.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/SpannerMockServerFixture.cs
@@ -20,7 +20,6 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
 {
     public class SpannerMockServerFixture : IDisposable
     {
-        private readonly object _lock = new object();
         private readonly Random _random = new Random();
 
         private readonly Server _server;
@@ -59,10 +58,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public long RandomLong(long min, long max)
         {
             byte[] buf = new byte[8];
-            lock (_lock)
-            {
-                _random.NextBytes(buf);
-            }
+            _random.NextBytes(buf);
             long longRand = BitConverter.ToInt64(buf, 0);
             return (Math.Abs(longRand % (max - min)) + min);
         }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/xunit.runner.json
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/xunit.runner.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-    "parallelizeTestCollections":  false
+    "parallelizeTestCollections":  true
 }


### PR DESCRIPTION
Unflakes the `AbortedTransactionsTest`. The flaky failures were caused by the fact that the mock server would write all responses to the stream for `ExecuteStreamingSql` as quickly as it could. That could in some cases cause the results to all have been sent to the client before the test expected it. The mock server has now been equipped with a mechanism that allows the test client to throttle writes to the stream until it wants it to be written. This makes it possible to guarantee when results are received by the client, and thereby guarantee the correct behavior of the client under specific cirumstances.