### PR TITLE
Update workflow to timeout after 10 minutes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     services:
       emulator:


### PR DESCRIPTION
Workflow seems to take about 5 minutes when it's working.
Use timeout of 10 minutes so that it doesn't eat up all the actions minutes quota (default timeout is 360 minutes)
