### PR TITLE
test: rollback should not clear the _abortNextStatement flag

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MockSpannerServer.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MockSpannerServer.cs
@@ -351,6 +351,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             _contexts = new ConcurrentQueue<ServerCallContext>();
             _executionTimes.Clear();
             _results.Clear();
+            _abortedTransactions.Clear();
+            _abortNextStatement = false;
         }
 
         public override Task<Transaction> BeginTransaction(BeginTransactionRequest request, ServerCallContext context)
@@ -385,7 +387,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             _requests.Enqueue(request);
             _contexts.Enqueue(context);
             TryFindSession(request.SessionAsSessionName);
-            TryFindTransaction(request.TransactionId, true);
+            _transactions.TryRemove(request.TransactionId, out _);
             return Task.FromResult(EMPTY);
         }
 


### PR DESCRIPTION
A rollback request could clear the _abortNextStatement flag. This would mean that
an async Rollback request could affect a later test case that was using the same
fixture if the Rollback request would be processed after the _abortNextStatement
flag had been set by the following test case.

Fixes #95
