### PR TITLE
test: use unicode for random strings

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SpannerFixtureBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SpannerFixtureBase.cs
@@ -86,9 +86,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
 
         public string RandomString(int length, Random rnd)
         {
-            byte[] buf = new byte[length];
+            byte[] buf = new byte[length * 4];
             rnd.NextBytes(buf);
-            return System.Text.Encoding.ASCII.GetString(buf);
+            return System.Text.Encoding.Unicode.GetString(buf).Substring(0, 4);
         }
     }
 }


### PR DESCRIPTION
Random strings should use Unicode instead of ASCII encoding to ensure that the generated
string is actually random, and not '????'.

Fixes #112
