### PR TITLE
chore: add new keyword for methods that hide a super class method

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableConnection.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableConnection.cs
@@ -129,7 +129,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// retried if one of the statements on the transaction is aborted by Cloud Spanner.
         /// </summary>
         /// <returns>A new read/write transaction with internal retries enabled.</returns>
-        public Task<SpannerRetriableTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+        public new Task<SpannerRetriableTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
             => BeginTransactionAsync(IsolationLevel.Unspecified, cancellationToken);
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// </summary>
         /// <returns>A new read/write transaction with internal retries enabled.</returns>
         /// <exception cref="NotSupportedException"/>
-        public async Task<SpannerRetriableTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+        public new async Task<SpannerRetriableTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
         {
             if (isolationLevel != IsolationLevel.Unspecified
                 && isolationLevel != IsolationLevel.Serializable)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
@@ -298,7 +298,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// </summary>
         /// <param name="cancellationToken">A cancellation token used for this task.</param>
         /// <returns>Returns the UTC timestamp when the data was written to the database.</returns>
-        public async Task<DateTime> CommitAsync(CancellationToken cancellationToken = default)
+        public new async Task<DateTime> CommitAsync(CancellationToken cancellationToken = default)
         {
             var tracer = TracerProviderExtension.GetTracer();
             using var span = tracer.StartActiveSpan(TracerProviderExtension.SPAN_NAME_COMMIT);


### PR DESCRIPTION
Fixes warnings in PRs about missing `new` keyword for methods that hide a superclass method.