### PR TITLE
chore: release EntityFrameworkCore.Spanner v1.0.0

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.csproj
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>spanner;entity framework;Google;Cloud;efcore</PackageTags>
     <PackageIcon>NuGetIcon.png</PackageIcon>
-    <Version>0.2.0</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google.Cloud.EntityFrameworkCore.Spanner
 [Google Cloud Spanner](https://cloud.google.com/spanner/docs/) database provider for [Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/).
 
-This project has __Preview__ release status. Known limitations are listed in the [issues](https://github.com/cloudspannerecosystem/dotnet-spanner-entity-framework/issues?q=is%3Aissue+is%3Aopen+label%3A%22known+limitation%22) list.
+Known limitations are listed in the [issues](https://github.com/cloudspannerecosystem/dotnet-spanner-entity-framework/issues?q=is%3Aissue+is%3Aopen+label%3A%22known+limitation%22) list.
 All supported features have been tested and verified to work with the test configurations. There may be configurations and/or data model variations that have not
 yet been covered by the tests and that show unexpected behavior. Please report any problems that you might encounter by [creating a new issue](https://github.com/cloudspannerecosystem/dotnet-spanner-entity-framework/issues/new).
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,3 +1,11 @@
+# Version 1.0.0, released 2021-09-09
+
+- [Commit baee99b](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/baee99b) feat: support single stale reads ([#120](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/120))
+- [Commit 429486c](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/429486c) fix: use build instead of revision in version ([#118](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/118))
+- [Commit 7bfb5e4](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/7bfb5e4) test: use assembly version instead of hard coded string ([#114](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/114))
+- [Commit 0c4b76a](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/0c4b76a) test: use unicode for random strings ([#115](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/115))
+- [Commit 1869689](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/1869689) test: rollback should not clear the \_abortNextStatement flag ([#110](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/110))
+
 # Version 0.2.0, released 2021-09-03
 
 - [Commit 6664d8d](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/6664d8d) test: add test to verify the use of DDL batches ([#92](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/92))


### PR DESCRIPTION
Changes in Google.Cloud.EntityFrameworkCore.Spanner version 1.0.0:

- [Commit baee99b](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/baee99b) feat: support single stale reads ([#120](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/120))
- [Commit 429486c](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/429486c) fix: use build instead of revision in version ([#118](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/118))
- [Commit 7bfb5e4](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/7bfb5e4) test: use assembly version instead of hard coded string ([#114](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/114))
- [Commit 0c4b76a](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/0c4b76a) test: use unicode for random strings ([#115](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/115))
- [Commit 1869689](https://github.com/googleapis/dotnet-spanner-entity-framework/commit/1869689) test: rollback should not clear the \_abortNextStatement flag ([#110](https://github.com/googleapis/dotnet-spanner-entity-framework/pull/110))
    
Packages in this release:
- Release Google.Cloud.EntityFrameworkCore.Spanner version 1.0.0