### PR TITLE
build: rename default branch to main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   unit-tests:

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   integration-tests-on-emulator:

--- a/.github/workflows/integration-tests-on-production.yml
+++ b/.github/workflows/integration-tests-on-production.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   check-env:


### PR DESCRIPTION
Updates the references to the default branch from `master` to `main` in the GitHub Actions workflows.