### PR TITLE
fix: DataReader.GetFieldValue<T> could fail for array types

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Google.Cloud.EntityFrameworkCore.Spanner.Tests.csproj
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Google.Cloud.EntityFrameworkCore.Spanner.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.20" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.Combinatorial" Version="1.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/SpannerConverter.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/SpannerConverter.cs
@@ -83,6 +83,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
                         StringValue = StripTimePart(
                             XmlConvert.ToString(Convert.ToDateTime(value, InvariantCulture), XmlDateTimeSerializationMode.Utc))
                     };
+                case TypeCode.Json:
+                    if (value is string stringValue)
+                    {
+                        return new Value { StringValue = stringValue };
+                    }
+                    throw new ArgumentException("JSON values must be given as string");
                 case TypeCode.Array:
                     if (value is IEnumerable enumerable)
                     {

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
@@ -282,6 +282,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             return _spannerDataReader.GetValue(ordinal);
         }
 
+        public override T GetFieldValue<T>(int ordinal)
+        {
+            return _spannerDataReader.GetFieldValue<T>(ordinal);
+        }
+
         public override int GetValues(object[] values)
         {
             return _spannerDataReader.GetValues(values);


### PR DESCRIPTION
Calling DataReader.GetFieldValue<T>(int) could fail if the column was an array and that
array contained at least one null element. This would only happen if all the following
conditions were met:
1. The query was executed as part of a read/write transaction.
2. The default type for the array element type is not nullable (e.g. long, double, SpannerNumeric)
3. The array in the Cloud Spanner table contained at least one NULL element.

Fixes #143