### PR TITLE
build: use v0 instead of master

### DIFF
--- a/.github/workflows/integration-tests-on-production.yml
+++ b/.github/workflows/integration-tests-on-production.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Setup GCloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
Use v0 instead of master, as master is no longer supported.