### PR TITLE
fix: update requirements hash

### DIFF
--- a/.kokoro/requirements.txt
+++ b/.kokoro/requirements.txt
@@ -139,8 +139,8 @@ importlib-metadata==4.12.0 \
     --hash=sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23
     # via keyring
 jaraco-classes==3.2.3 \
-    --hash=sha256:6745f113b0b588239ceb49532aa09c3ebb947433ce311ef2f8e3ad64ebb74594 \
-    --hash=sha256:e6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647
+    --hash=sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158 \
+    --hash=sha256:89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a
     # via keyring
 jinja2==3.1.2 \
     --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \


### PR DESCRIPTION
Fixes a missing hash update in the requirements.txt file that failed the release build.