### PR TITLE
fix: missing select column TABLE_NAME in scaffolding

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner/Scaffolding/Internal/SpannerDatabaseModelFactory.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Scaffolding/Internal/SpannerDatabaseModelFactory.cs
@@ -111,7 +111,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Scaffolding.Internal
         {
             using var command = connection.CreateCommand();
             var commandText = @"
-                SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT,
+                SELECT TABLE_NAME, COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT,
                        IS_GENERATED, GENERATION_EXPRESSION
                 FROM INFORMATION_SCHEMA.COLUMNS
                 WHERE TABLE_CATALOG = '' AND TABLE_SCHEMA = ''


### PR DESCRIPTION
this will cause error when run database first migration

Fixes #233 

> It's a good idea to open an issue first for discussion.

- [ V ] Tests pass
- [ X ] Appropriate changes to README are included in PR