### PR TITLE
fix: prevent errors with newlines by using triple-quoted literals

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210830082803_Initial.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/Migrations/20210830082803_Initial.cs
@@ -199,7 +199,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.MigrationTes
                 values: new object[,]
                 {
                     { 1L, "Belinda", "Stiles" },
-                    { 2L, "Kelly", "Houser" }
+                    { 2L, "Kelly", "Houser" },
+                    { 3L, "Barnie", "Stones\nWith\nNewline"}
                 });
 
             migrationBuilder.CreateIndex(

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/SpannerMigrationTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/MigrationTests/SpannerMigrationTest.cs
@@ -502,7 +502,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
                     ArticleId = 1,
                     Author = new Author
                     {
-                        AuthorId = 3,
+                        AuthorId = 4,
                         FirstName = "Calvin",
                         LastName = "Saunders"
                     },

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -28,6 +28,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -332,7 +333,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         [Fact]
         public async Task CanReadWithExactStaleness()
         {
-            var sql = AddFindSingerResult($"-- exact_staleness: 5.5{Environment.NewLine}{Environment.NewLine}" +
+            var sql = AddFindSingerResult($"-- exact_staleness: 5{CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator}5{Environment.NewLine}{Environment.NewLine}" +
                                           $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, " +
                                           $"`s`.`LastName`, `s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
                                           $"WHERE `s`.`SingerId` = @__id_0{Environment.NewLine}LIMIT 1");
@@ -885,7 +886,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             using var db = new MockServerSampleDbContext(ConnectionString);
             var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
                 $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
-                $"WHERE (@__fullName_0 = '') OR STARTS_WITH(`s`.`FullName`, @__fullName_0)";
+                $"WHERE (@__fullName_0 = '''''') OR STARTS_WITH(`s`.`FullName`, @__fullName_0)";
             AddFindSingerResult(sql);
 
             var fullName = "Alice M";
@@ -910,7 +911,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             using var db = new MockServerSampleDbContext(ConnectionString);
             var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, " +
                 $"`s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
-                $"WHERE (@__fullName_0 = '') OR ENDS_WITH(`s`.`FullName`, @__fullName_0)";
+                $"WHERE (@__fullName_0 = '''''') OR ENDS_WITH(`s`.`FullName`, @__fullName_0)";
             AddFindSingerResult(sql);
 
             var fullName = " Morrison";
@@ -958,7 +959,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseStringConcat()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT CONCAT(`s`.`FirstName`, ' ', `s`.`LastName`, CAST(`s`.`SingerId` AS STRING)){Environment.NewLine}" + 
+            var sql = $"SELECT CONCAT(`s`.`FirstName`, ''' ''', `s`.`LastName`, CAST(`s`.`SingerId` AS STRING)){Environment.NewLine}" + 
                       $"FROM `Singers` AS `s`{Environment.NewLine}" + 
                       "LIMIT 1";
             AddFindSingerResult(sql);
@@ -980,7 +981,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseStringPlus()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT (COALESCE(`s`.`FirstName`, '')||' ')||`s`.`LastName`{Environment.NewLine}" + 
+            var sql = $"SELECT (COALESCE(`s`.`FirstName`, '''''')||''' ''')||`s`.`LastName`{Environment.NewLine}" + 
                       $"FROM `Singers` AS `s`{Environment.NewLine}" + 
                       "LIMIT 1";
             AddFindSingerResult(sql);
@@ -1852,7 +1853,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         public async Task CanUseDateTimeToString()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
-            var sql = $"SELECT FORMAT_TIMESTAMP('%FT%H:%M:%E*SZ', COALESCE(`t`.`ColTimestamp`, TIMESTAMP '0001-01-01T00:00:00Z'), 'UTC')" +
+            var sql = $"SELECT FORMAT_TIMESTAMP('''%FT%H:%M:%E*SZ''', COALESCE(`t`.`ColTimestamp`, TIMESTAMP '0001-01-01T00:00:00Z'), '''UTC''')" +
                 $"{Environment.NewLine}FROM `TableWithAllColumnTypes` AS `t`{Environment.NewLine}WHERE `t`.`ColInt64` = @__id_0" +
                 $"{Environment.NewLine}LIMIT 1";
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/MigrationMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/MigrationMockServerTests.cs
@@ -44,11 +44,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.MigrationTests
             var formattedVersion = $"{version.Major}.{version.Minor}.{version.Build}";
             _fixture.SpannerMock.AddOrUpdateStatementResult("SELECT 1", StatementResult.CreateException(MockSpannerService.CreateDatabaseNotFoundException("d1")));
             _fixture.SpannerMock.AddOrUpdateStatementResult(
-                $"INSERT INTO `EFMigrationsHistory` (`MigrationId`, `ProductVersion`)\nVALUES ('20210309110233_Initial', '{formattedVersion}')",
+                $"INSERT INTO `EFMigrationsHistory` (`MigrationId`, `ProductVersion`)\nVALUES ('''20210309110233_Initial''', '''{formattedVersion}''')",
                 StatementResult.CreateUpdateCount(1)
             );
             _fixture.SpannerMock.AddOrUpdateStatementResult(
-                $"INSERT INTO `EFMigrationsHistory` (`MigrationId`, `ProductVersion`)\nVALUES ('20210830_V2', '{formattedVersion}')",
+                $"INSERT INTO `EFMigrationsHistory` (`MigrationId`, `ProductVersion`)\nVALUES ('''20210830_V2''', '''{formattedVersion}''')",
                 StatementResult.CreateUpdateCount(1)
             );
             using var db = new MockMigrationSampleDbContext(ConnectionString);

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -444,10 +444,10 @@ CONSTRAINT `Chk_Title_Length_Equal` CHECK (CHARACTER_LENGTH(Title) > 0),
         {
             base.InsertDataOperation();
             AssertSql(@"INSERT INTO `Singers` (`SingerId`, `FirstName`, `LastName`)
-VALUES (1, 'Marc', 'Richards'),
-(2, 'Catalina', 'Smith'),
-(3, 'Alice', 'Trentor'),
-(4, 'Lea', 'Martin');
+VALUES (1, '''Marc''', '''Richards'''),
+(2, '''Catalina''', '''Smith'''),
+(3, '''Alice''', '''Trentor'''),
+(4, '''Lea''', '''Martin''');
 ");
         }
 
@@ -467,9 +467,9 @@ WHERE `SingerId` = 3;
         {
             base.DeleteDataOperation_composite_key();
             AssertSql(@"DELETE FROM `Singers`
-WHERE `FirstName` = 'Dorothy' AND `LastName` IS NULL;
+WHERE `FirstName` = '''Dorothy''' AND `LastName` IS NULL;
 DELETE FROM `Singers`
-WHERE `FirstName` = 'Curt' AND `LastName` = 'Lee';
+WHERE `FirstName` = '''Curt''' AND `LastName` = '''Lee''';
 ");
         }
 
@@ -477,9 +477,9 @@ WHERE `FirstName` = 'Curt' AND `LastName` = 'Lee';
         public override void UpdateDataOperation_simple_key()
         {
             base.UpdateDataOperation_simple_key();
-            AssertSql(@"UPDATE `Singers` SET `FirstName` = 'Christopher'
+            AssertSql(@"UPDATE `Singers` SET `FirstName` = '''Christopher'''
 WHERE `SingerId` = 1;
-UPDATE `Singers` SET `FirstName` = 'Lisa'
+UPDATE `Singers` SET `FirstName` = '''Lisa'''
 WHERE `SingerId` = 4;
 ");
         }
@@ -488,9 +488,9 @@ WHERE `SingerId` = 4;
         public override void UpdateDataOperation_composite_key()
         {
             base.UpdateDataOperation_composite_key();
-            AssertSql(@"UPDATE `Albums` SET `Title` = 'Total Junk'
+            AssertSql(@"UPDATE `Albums` SET `Title` = '''Total Junk'''
 WHERE `SingerId` = 1 AND `AlbumId` = 1;
-UPDATE `Albums` SET `Title` = 'Terrified'
+UPDATE `Albums` SET `Title` = '''Terrified'''
 WHERE `SingerId` = 1 AND `AlbumId` = 2;
 ");
         }
@@ -499,9 +499,9 @@ WHERE `SingerId` = 1 AND `AlbumId` = 2;
         public override void UpdateDataOperation_multiple_columns()
         {
             base.UpdateDataOperation_multiple_columns();
-            AssertSql(@"UPDATE `Singers` SET `FirstName` = 'Gregory', `LastName` = 'Davis'
+            AssertSql(@"UPDATE `Singers` SET `FirstName` = '''Gregory''', `LastName` = '''Davis'''
 WHERE `SingerId` = 1;
-UPDATE `Singers` SET `FirstName` = 'Katherine', `LastName` = 'Palmer'
+UPDATE `Singers` SET `FirstName` = '''Katherine''', `LastName` = '''Palmer'''
 WHERE `SingerId` = 4;
 ");
         }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerJsonTypeMapping.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerJsonTypeMapping.cs
@@ -52,11 +52,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         {
             if (value is JsonDocument jd)
             {
-                return $"'{jd.RootElement.ToString()}'";
+                return $"JSON '{jd.RootElement.ToString()}'";
             }
             if (value is string s)
             {
-                return $"'{s}'";
+                return $"JSON '{s}'";
             }
             throw new ArgumentException($"{value} is not valid for database type JSON");
         }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerStringTypeMapping.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerStringTypeMapping.cs
@@ -75,5 +75,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 ? _maxSpecificSize
                 : 0;
         }
+
+        protected override string GenerateNonNullSqlLiteral(object value)
+            => $"'''{value}'''";
     }
 }


### PR DESCRIPTION
Prevent errors when generating string literals by using triple-quoted literals. These allow unescaped newlines and quotes inside the string.

Fixes #273
