### PR TITLE
fix: EnsureCreated should skip validation before migration

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/SpannerSampleDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/SpannerSampleDbContext.cs
@@ -120,6 +120,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model
                 entity.Property(e => e.FullName)
                     .IsRequired()
                     .HasMaxLength(400)
+                    .HasComputedColumnSql("(COALESCE(FirstName || ' ', '') || LastName) STORED")
                     .ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.LastName)
@@ -187,8 +188,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model
                 entity.HasOne(d => d.Album)
                     .WithMany(p => p.Tracks)
                     .HasForeignKey(d => d.AlbumId)
-                    .OnDelete(DeleteBehavior.ClientSetNull)
-                    .HasConstraintName("PK_Albums");
+                    .OnDelete(DeleteBehavior.ClientSetNull);
             });
 
             modelBuilder.Entity<Venues>(entity =>

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/QueryTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/QueryTests.cs
@@ -29,11 +29,16 @@ using SpannerDate = Google.Cloud.EntityFrameworkCore.Spanner.Storage.SpannerDate
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
 {
-    public class QueryTests : IClassFixture<SpannerSampleFixture>
+    public class QueryTestFixture : SpannerSampleFixture
     {
-        private readonly SpannerSampleFixture _fixture;
+        protected override bool UseEnsureCreated => true;
+    }
 
-        public QueryTests(SpannerSampleFixture fixture) => _fixture = fixture;
+    public class QueryTests : IClassFixture<QueryTestFixture>
+    {
+        private readonly QueryTestFixture _fixture;
+
+        public QueryTests(QueryTestFixture fixture) => _fixture = fixture;
 
         [Fact]
         public async Task CanFilterOnProperty()

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SpannerSampleFixture.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SpannerSampleFixture.cs
@@ -88,6 +88,8 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
             Logger.DefaultLogger.Debug($"Ready to run tests");
         }
 
+        protected virtual bool UseEnsureCreated => false;
+
         private void ClearTables()
         {
             using var con = GetConnection();
@@ -117,6 +119,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests
         /// </summary>
         private void CreateTables()
         {
+            if (UseEnsureCreated)
+            {
+                using var db = new TestSpannerSampleDbContext(DatabaseName);
+                db.Database.EnsureCreated();
+                return;
+            }
             var dirPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             const string sampleModel = "SampleDataModel.sql";
             var fileName = Path.Combine(dirPath, sampleModel);

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleRunner.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleRunner.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Infrastructure/Internal/SpannerModelValidator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Infrastructure/Internal/SpannerModelValidator.cs
@@ -74,10 +74,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Infrastructure.Internal
             // In that case we should also skip the further validation, as the differences
             // could be a result of migrations that still need to be executed.
             var facadeExtensions = nameof(RelationalDatabaseFacadeExtensions);
+            var databaseFacade = nameof(DatabaseFacade);
             var migrateMethods = new List<string>
             {
                 nameof(RelationalDatabaseFacadeExtensions.Migrate),
                 nameof(RelationalDatabaseFacadeExtensions.MigrateAsync),
+                nameof(DatabaseFacade.EnsureCreated),
+                nameof(DatabaseFacade.EnsureCreatedAsync),
+                nameof(DatabaseFacade.EnsureDeleted),
+                nameof(DatabaseFacade.EnsureDeletedAsync)
             };
             var migrationsOperations = nameof(MigrationsOperations);
             var migrationsOperationsMethods = new List<string>
@@ -93,7 +98,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Infrastructure.Internal
             do
             {
                 method = new StackFrame(skipFrames, false).GetMethod();
-                if (method != null && migrateMethods.Contains(method.Name) && facadeExtensions.Equals(method.DeclaringType.Name))
+                if (method != null && migrateMethods.Contains(method.Name) && (facadeExtensions.Equals(method.DeclaringType.Name) || databaseFacade.Equals(method.DeclaringType.Name)))
                 {
                     return;
                 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDatabaseCreator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDatabaseCreator.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal


### PR DESCRIPTION
The DatabaseFacade.EnsureCreated() method would not work, as it would try to do a model validation before actually creating the database. This would fail for databases that are empty.

Fixes #286
