### PR TITLE
fix: dispose the underlying SpannerDataReader

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -2279,6 +2279,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
                 cmd.Transaction = transaction;
             }
             using var reader = await cmd.ExecuteReaderAsync();
+            if (useTransaction)
+            {
+                Assert.False(((SpannerDataReaderWithChecksum)reader).SpannerDataReader.IsClosed);
+            }
             while (await reader.ReadAsync())
             {
                 Assert.Equal(1L, reader.GetInt64(0));
@@ -2306,6 +2310,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
                 Assert.Equal(new List<DateTime?>{new DateTime(2021, 12, 1), new DateTime(2000, 2, 29), null}, reader.GetFieldValue<List<DateTime?>>(15));
                 Assert.Equal(new List<DateTime?>{new DateTime(2021, 12, 1, 11, 17, 2, DateTimeKind.Utc), null}, reader.GetFieldValue<List<DateTime?>>(16));
                 Assert.Equal(new List<string>{"{\"key1\": \"value1\", \"key2\": \"value2\"}", "{\"key1\": \"value3\", \"key2\": \"value4\"}", null}, reader.GetFieldValue<List<string>>(17));
+            }
+            await reader.DisposeAsync();
+            if (useTransaction)
+            {
+                Assert.True(((SpannerDataReaderWithChecksum)reader).SpannerDataReader.IsClosed);
             }
             if (useTransaction)
             {

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Properties/AssemblyInfo.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Properties/AssemblyInfo.cs
@@ -13,5 +13,7 @@
 // limitations under the License.
 
 using Microsoft.EntityFrameworkCore.Design;
+using System.Runtime.CompilerServices;
 
 [assembly: DesignTimeProviderServices("Google.Cloud.EntityFrameworkCore.Spanner.Design.Internal.SpannerDesignTimeServices")]
+[assembly:InternalsVisibleTo("Google.Cloud.EntityFrameworkCore.Spanner.Tests")]

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Apis.Testing;
 using Google.Cloud.Spanner.Data;
 using Google.Protobuf;
 using System;
@@ -58,6 +59,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         public override bool IsClosed => _spannerDataReader.IsClosed;
 
         public override int RecordsAffected => _spannerDataReader.RecordsAffected;
+
+        [VisibleForTestOnly]
+        internal SpannerDataReader SpannerDataReader => _spannerDataReader;
 
         public override object this[string name] => _spannerDataReader[name];
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
@@ -65,6 +65,18 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         private SpannerDataReader _spannerDataReader;
 
+        public override void Close()
+        {
+            _spannerDataReader.Close();
+            base.Close();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _spannerDataReader.Dispose();
+            base.Dispose(disposing);
+        }
+
         /// <inheritdoc />
         public override bool Read() => Task.Run(() => ReadAsync(CancellationToken.None)).ResultWithUnwrappedExceptions();
 


### PR DESCRIPTION
The SpannerDataReaderWithChecksum did not dispose the underlying SpannerDataReader when it was closed/disposed. This caused unnecessary logging to happen that indicated that a session could have been leaked. The failure to close the underlying reader would however not cause a session leak, as the session is managed by the surrounding transaction, which again will return the session to the pool when the transaction is disposed.
