### PR TITLE
deps: bump gRPC dependencies

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Google.Cloud.EntityFrameworkCore.Spanner.Tests.csproj
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Google.Cloud.EntityFrameworkCore.Spanner.Tests.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.53.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.53.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.56.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.56.0" />
     <PackageReference Include="Grpc.Core.Api" Version="2.56.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
-    <PackageReference Include="Grpc.Net.Common" Version="2.53.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.54.0">
+    <PackageReference Include="Grpc.Net.Client" Version="2.56.0" />
+    <PackageReference Include="Grpc.Net.Common" Version="2.56.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.57.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bump all gRPC dependency versions at once, as doing them one-by-one causes build errors.