### PR TITLE
chore: run Emulator on random port when running sample

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/EmulatorRunner.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/EmulatorRunner.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples
         /// <summary>
         /// Downloads the latest Spanner emulator docker image and starts the emulator on port 9010.
         /// </summary>
-        internal async Task StartEmulator()
+        internal async Task<PortBinding> StartEmulator()
         {
             await PullEmulatorImage();
             var response = await _dockerClient.Containers.CreateContainerAsync(new CreateContainerParameters
@@ -54,13 +54,14 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples
                 {
                     PortBindings = new Dictionary<string, IList<PortBinding>>
                     {
-                        {"9010", new List<PortBinding> {new PortBinding {HostPort = "9010"}}}
+                        {"9010", default}
                     },
-                    PublishAllPorts = true
                 }
             });
             _containerId = response.ID;
             await _dockerClient.Containers.StartContainerAsync(_containerId, null);
+            var inspectResponse = await _dockerClient.Containers.InspectContainerAsync(_containerId);
+            return inspectResponse.NetworkSettings.Ports["9010/tcp"][0];
         }
 
         /// <summary>

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleRunner.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleRunner.cs
@@ -71,14 +71,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples
 
         internal static async Task RunSampleAsync(Func<string, Task> sampleMethod)
         {
-            Environment.SetEnvironmentVariable("SPANNER_EMULATOR_HOST", "localhost:9010");
             var emulatorRunner = new EmulatorRunner();
             try
             {
                 Console.WriteLine("");
                 Console.WriteLine("Starting emulator...");
-                emulatorRunner.StartEmulator().WaitWithUnwrappedExceptions();
+                var portBinding = await emulatorRunner.StartEmulator();
+                Console.WriteLine($"Emulator started on port {portBinding.HostPort}");
                 Console.WriteLine("");
+                Environment.SetEnvironmentVariable("SPANNER_EMULATOR_HOST", $"localhost:{portBinding.HostPort}");
 
                 var projectId = "sample-project";
                 var instanceId = "sample-instance";


### PR DESCRIPTION
Run the emulator on a random port when starting it embedded with a sample. This prevents port collisions if the emulator is already running, and makes it easier to set up a test runner for the samples.
