### PR TITLE
fix - add missing async methods

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerReadOnlyTransaction.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerReadOnlyTransaction.cs
@@ -95,5 +95,13 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             command.Transaction = SpannerTransaction;
             return command.ExecuteReader();
         }
+
+        /// <inheritdoc/>
+        protected async internal override Task<DbDataReader> ExecuteDbDataReaderWithRetryAsync(SpannerCommand command, CancellationToken cancellationToken)
+        {
+            GaxPreconditions.CheckState(!Disposed, "This transaction has been disposed");
+            command.Transaction = SpannerTransaction;
+            return await command.ExecuteReaderAsync(cancellationToken);
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableCommand.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableCommand.cs
@@ -111,6 +111,22 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             return _spannerCommand.ExecuteReader();
         }
 
+        protected async override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            if (_transaction != null)
+            {
+                return await _transaction.ExecuteDbDataReaderWithRetryAsync(_spannerCommand, cancellationToken);
+            }
+
+            // These don't need retry protection as the ephemeral transaction used by the client library is a read-only transaction.
+            if (TimestampBound != null)
+            {
+                return await _spannerCommand.ExecuteReaderAsync(TimestampBound);
+            }
+            return await _spannerCommand.ExecuteReaderAsync();
+
+        }
+
         public override void Prepare() => _spannerCommand.Prepare();
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableConnection.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableConnection.cs
@@ -17,6 +17,7 @@ using Google.Cloud.Spanner.Data;
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Runtime.Intrinsics.Arm;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -217,5 +218,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         /// <inheritdoc/>
         public override void Open() => SpannerConnection.Open();
+
+        public override Task OpenAsync(CancellationToken cancellationToken) => SpannerConnection.OpenAsync(cancellationToken);
+
+        public override Task CloseAsync() => SpannerConnection.CloseAsync();
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTransactionBase.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTransactionBase.cs
@@ -97,5 +97,18 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// the entire transaction if the result stream returns an Aborted error.
         /// </returns>
         protected internal abstract DbDataReader ExecuteDbDataReaderWithRetry(SpannerCommand command);
+
+        /// <summary>
+        /// Executes a <see cref="SpannerCommand"/> a query and returns the result as a
+        /// <see cref="DbDataReader"/> that will retry the entire transaction if the query or any
+        /// of the results of the underlying stream of PartialResultSets returns an Aborted error.
+        /// </summary>
+        /// <param name="command">The command to execute. Must be a DML or mutation command.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>
+        /// The results of the query as a <see cref="DbDataReader"/> that will automatically retry
+        /// the entire transaction if the result stream returns an Aborted error.
+        /// </returns>
+        protected internal abstract Task<DbDataReader> ExecuteDbDataReaderWithRetryAsync(SpannerCommand command, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Fixes #396
This PR provides the following async method implementations that are missing:

SpannerReadOnlyTransaction.ExecuteDbDataReaderWithRetryAsync
SpannerRetriableCommand.ExecuteDbDataReaderAsync
SpannerRetriableConnection.OpenAsync
SpannerRetriableConnection.CloseAsync
SpannerRetriableTransaction.ExecuteDbDataReaderWithRetryAsync