### PR TITLE
deps: configure renovate to use deps: prefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "baseBranches": ["main", "v3.1"],
+  "semanticCommitType": "deps",
+  "semanticCommitScope": "",
   "extends": [
     "config:base"
   ]


### PR DESCRIPTION
Configure renovate to use `deps:` commit prefix, so new deps trigger a new release.
