### PR TITLE
feat: retry DML with THEN RETURN in transactions

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MockSpannerServer.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MockSpannerServer.cs
@@ -69,6 +69,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         }
 
         internal static StatementResult CreateSingleColumnResultSet(V1.Type type, string col, params object[] values)
+            => CreateSingleColumnResultSet(null, type, col, values);
+
+        internal static StatementResult CreateSingleColumnResultSet(long? updateCount, V1.Type type, string col, params object[] values)
         {
             ResultSet rs = new ResultSet
             {
@@ -87,6 +90,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
                 ListValue row = new ListValue();
                 row.Values.Add(SpannerConverter.ToProtobufValue(type, val));
                 rs.Rows.Add(row);
+            }
+            if (updateCount != null)
+            {
+                rs.Stats = new ResultSetStats { RowCountExact = updateCount.Value };
             }
             return CreateQuery(rs);
         }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
@@ -224,13 +224,30 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         private async Task<SpannerDataReaderWithChecksum> ExecuteDbDataReaderWithRetryImplAsync(SpannerCommand command, CancellationToken cancellationToken)
         {
-            // This method does not need a retry loop as it is not actually executing the query. Instead,
-            // that will be deferred until the first call to DbDataReader.Read().
-            command.Transaction = SpannerTransaction;
-            var spannerReader = await command.ExecuteReaderAsync(cancellationToken);
-            var checksumReader = new SpannerDataReaderWithChecksum(this, spannerReader, command);
-            _retriableStatements.Add(checksumReader);
-            return checksumReader;
+            while (true)
+            {
+                command.Transaction = SpannerTransaction;
+                try
+                {
+                    var spannerReader = await command.ExecuteReaderAsync(cancellationToken);
+                    var checksumReader = new SpannerDataReaderWithChecksum(this, spannerReader, command);
+                    _retriableStatements.Add(checksumReader);
+                    return checksumReader;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    await RetryAsync(e, cancellationToken);
+                }
+                catch (SpannerException e)
+                {
+                    // We can use a FailedDmlStatement here, as reaching here means that the statement
+                    // failed directly when trying to execute a reader. That indicates that the underlying
+                    // statement was a DML statement with a THEN RETURN clause, and that all we need to
+                    // verify during the retry is that it returns the exact same error when it is executed.
+                    _retriableStatements.Add(new FailedDmlStatement(command, e));
+                    throw;
+                }
+            }
         }
 
         internal void Retry(SpannerException abortedException, int timeoutSeconds = MAX_TIMEOUT_SECONDS)


### PR DESCRIPTION
DML statements with a THEN RETURN clause need to be executed using the ExecuteReader method. These were normally not executed in a retry loop, as they were up until now only used for queries. Queries are executed during the first call to Reader#Read(), which meant that a retry loop was not needed for calls to ExecuteReader. DML statements with a THEN RETURN clause are executed directly, and therefore need a retry loop.

This fix adds a retry loop for that, and tests for DML statements with a THEN RETURN clause.
