### PR TITLE
docs: run samples on dotnet 6 and 8

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -8,12 +8,16 @@ on:
 jobs:
   run-samples:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet: [ "6.0", "8.0" ]
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: ${{matrix.dotnet}}.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -18,6 +18,9 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{matrix.dotnet}}.x
+    - name: Create global.json file
+      run: "echo '{\"sdk\":{\"version\": \"${{ steps.setup.outputs.dotnet-version }}\"}}' > ./global.json"
+    - run: dotnet --version
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
+      id: setup
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{matrix.dotnet}}.x

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/Google.Cloud.EntityFrameworkCore.Spanner.Samples.csproj
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/Google.Cloud.EntityFrameworkCore.Spanner.Samples.csproj
@@ -24,10 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Google.Cloud.EntityFrameworkCore.Spanner\Google.Cloud.EntityFrameworkCore.Spanner.csproj" />
+    <PackageReference Include="Google.Cloud.EntityFrameworkCore.Spanner" Version="2.1.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Sample showing that an application targeting .NET 6 and using version 2.x of the Spanner Entity Framework provider can use .NET 8 as the runtime version.