### PR TITLE
docs: target dotnet 8 in sample application

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -14,8 +14,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
-    - name: Create global.json file
-      run: "echo '{\"sdk\":{\"version\": \"${{ steps.setup.outputs.dotnet-version }}\"}}' > ./global.json"
     - run: dotnet --version
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -14,6 +14,9 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+    - name: Create global.json file
+      run: "echo '{\"sdk\":{\"version\": \"${{ steps.setup.outputs.dotnet-version }}\"}}' > ./global.json"
+    - run: dotnet --version
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/Google.Cloud.EntityFrameworkCore.Spanner.Samples.csproj
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/Google.Cloud.EntityFrameworkCore.Spanner.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>SampleRunner</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
@@ -24,10 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Google.Cloud.EntityFrameworkCore.Spanner\Google.Cloud.EntityFrameworkCore.Spanner.csproj" />
+    <PackageReference Include="Google.Cloud.EntityFrameworkCore.Spanner" Version="2.1.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Sample showing how to target .NET 8 in an application that uses version 2.x of the Spanner Entity Framework provider (which targets .NET 6).