### PR TITLE
ci: Remove unused values from release scripts

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -35,13 +35,7 @@ then
     populate_all_secrets
 fi
 
-export GOOGLE_APPLICATION_CREDENTIALS="$SECRETS_LOCATION/cloud-sharp-jenkins-compute-service-account"
-export REQUESTER_PAYS_CREDENTIALS="$SECRETS_LOCATION/gcloud-devel-service-account"
-
-PYTHON3=$(source toolversions.sh && echo $PYTHON3)
-DOCS_CREDENTIALS="$SECRETS_LOCATION/docuploader_service_account"
 GOOGLE_CLOUD_NUGET_API_KEY="$(cat "$SECRETS_LOCATION"/google-cloud-nuget-api-key)"
-GOOGLE_APIS_PACKAGES_NUGET_API_KEY="$(cat "$SECRETS_LOCATION"/google-apis-nuget-api-key)"
 
 COMMITTISH=$COMMITTISH_OVERRIDE
 if [[ $COMMITTISH_OVERRIDE = "" ]]


### PR DESCRIPTION
@olavloite I've removed from these scripts some values that you are not using, because you are not publishing docs with docuploader nor running integration tests on release. Can you please confirm all of that? Removing these makes migration easier.

@jskeet Equally, take a look and see if something seems not right. These scripts are originally copied from google-cloud-dotnet but we have diverged over time.

Marking as `do not merge` as I need to coordinate merging of this PR with some CLs. See b/371220760 for more information.