### PR TITLE
feat: add type mapping for int arrays and int lists

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/Performances.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/Performances.cs
@@ -16,6 +16,12 @@ using System;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model
 {
+    public enum PerformanceType
+    {
+        Live,
+        Playback,
+    }
+
     public partial class Performances
     {
         public string VenueCode { get; set; }
@@ -25,6 +31,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model
         public long TrackId { get; set; }
         public DateTime? StartTime { get; set; }
         public double? Rating { get; set; }
+        public PerformanceType PerformanceType { get; set; }
 
         public virtual Concerts Concerts { get; set; }
         public virtual Singers Singer { get; set; }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/SpannerSampleDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/SpannerSampleDbContext.cs
@@ -89,6 +89,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model
                     .HasName("PRIMARY_KEY");
 
                 entity.Property(e => e.VenueCode).HasMaxLength(10);
+                entity
+                    .Property(e => e.PerformanceType)
+                    .HasConversion(
+                        v => (int) v,
+                        v => (PerformanceType) v);
 
                 entity.HasOne(d => d.Singer)
                     .WithMany(p => p.Performances)

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SampleDataModel.sql
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/SampleDataModel.sql
@@ -71,6 +71,7 @@ CREATE TABLE Performances (
   TrackId          INT64 NOT NULL,
   StartTime        TIMESTAMP,
   Rating           FLOAT64,
+  PerformanceType  INT64,
   CONSTRAINT FK_Performances_Concerts FOREIGN KEY (VenueCode, ConcertStartTime, SingerId) REFERENCES Concerts (VenueCode, StartTime, SingerId),
   CONSTRAINT FK_Performances_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId),
   CONSTRAINT FK_Performances_Tracks FOREIGN KEY (AlbumId, TrackId) REFERENCES Tracks (AlbumId, TrackId),

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -143,6 +143,38 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         }
 
         [Fact]
+        public async Task FindSingersUsingListOfIntegers_UsesParameterizedQuery()
+        {
+            var sql = $"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, `s`.`LastName`, `s`.`Picture`{Environment.NewLine}" +
+                      $"FROM `Singers` AS `s`{Environment.NewLine}" +
+                      $"WHERE CAST(`s`.`SingerId` AS INT64) IN  UNNEST (@__singerIds_0)";
+            AddFindSingerResult(sql);
+
+            var singerIds = new List<int>{8, 9, 10};
+            using var db = new MockServerSampleDbContext(ConnectionString);
+            var singers = await db.Singers.Where(singer => singerIds.Contains((int) singer.SingerId)).ToListAsync();
+            Assert.Single(singers);
+            Assert.Collection(
+                _fixture.SpannerMock.Requests.OfType<ExecuteSqlRequest>(),
+                request =>
+                {
+                    Assert.Equal(sql, request.Sql);
+                    Assert.Single(request.Params.Fields);
+                    var fields = request.Params.Fields;
+                    Assert.Collection(fields["__singerIds_0"].ListValue.Values,
+                        v => Assert.Equal("8", v.StringValue),
+                        v => Assert.Equal("9", v.StringValue),
+                        v => Assert.Equal("10", v.StringValue)
+                    );
+                    Assert.Single(request.ParamTypes);
+                    var type = request.ParamTypes["__singerIds_0"];
+                    Assert.Equal(V1.TypeCode.Array, type.Code);
+                    Assert.Equal(V1.TypeCode.Int64, type.ArrayElementType.Code);
+                }
+            );
+        }
+
+        [Fact]
         public async Task FindSingerAsync_ReturnsInstance_IfFound()
         {
             var sql = AddFindSingerResult($"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`, " +

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMappingSource.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMappingSource.cs
@@ -132,6 +132,16 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         private static readonly SpannerComplexTypeMapping s_longList
             = new SpannerComplexTypeMapping(SpannerDbType.ArrayOf(SpannerDbType.Int64), typeof(List<long>));
 
+        private static readonly SpannerComplexTypeMapping s_nullableIntArray
+            = new SpannerComplexTypeMapping(SpannerDbType.ArrayOf(SpannerDbType.Int64), typeof(int?[]));
+        private static readonly SpannerComplexTypeMapping s_intArray
+            = new SpannerComplexTypeMapping(SpannerDbType.ArrayOf(SpannerDbType.Int64), typeof(int[]));
+
+        private static readonly SpannerComplexTypeMapping s_nullableIntList
+            = new SpannerComplexTypeMapping(SpannerDbType.ArrayOf(SpannerDbType.Int64), typeof(List<int?>));
+        private static readonly SpannerComplexTypeMapping s_intList
+            = new SpannerComplexTypeMapping(SpannerDbType.ArrayOf(SpannerDbType.Int64), typeof(List<int>));
+
         private static readonly SpannerNullableDateArrayTypeMapping s_nullableDateArray = new SpannerNullableDateArrayTypeMapping();
         private static readonly SpannerDateArrayTypeMapping s_dateArray = new SpannerDateArrayTypeMapping();
 
@@ -217,6 +227,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                     {typeof(double?[]), s_nullableDoubleArray},
                     {typeof(List<double>), s_doubleList},
                     {typeof(List<double?>), s_nullableDoubleList},
+                    {typeof(int[]), s_intArray},
+                    {typeof(int?[]), s_nullableIntArray},
+                    {typeof(List<int>), s_intList},
+                    {typeof(List<int?>), s_nullableIntList},
                     {typeof(long[]), s_longArray},
                     {typeof(long?[]), s_nullableLongArray},
                     {typeof(List<long>), s_longList},


### PR DESCRIPTION
int[], int?[], List<int>, and List<int?> did not have a type mapping for Spanner. This again meant that if they were used to for example filter based on a list of identifiers, that it would be sent to Spanner as a list of literals instead of query parameters. This adds a type mapping for these types to the ARRAY<INT64> type in Spanner.
