### PR TITLE
ci: Simplify release and build scripts.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,110 +2,18 @@
 
 set -e
 
-cd $(dirname $0)
+export ContinuousIntegrationBuild=true
+export Configuration=Release
 
-source toolversions.sh
+echo Building...
+dotnet build -nologo -clp:NoSummary -v quiet Google.Cloud.EntityFrameworkCore.Spanner
 
-# Make it easier to handle globbing that doesn't
-# match anything, e.g. when looking for tests.
-shopt -s nullglob
+echo Testing...
+dotnet test -nologo --no-build -v quiet Google.Cloud.EntityFrameworkCore.Spanner.Tests
 
-# Command line arguments are the APIs to build. Each argument
-# should be the name of a directory, either relative to the location
-# of this script, or under apis.
-# Additional arguments:
-# --notests: Just build, don't run the tests
-# --nobuild: Just list which APIs would be built; don't run the build
-# --coverage: Run tests with coverage enabled
-apis=()
-runtests=true
-runcoverage=false
-apiregex=
-nobuild=false
-diff=false
-while (( "$#" )); do
-  if [[ "$1" == "--notests" ]]
-  then
-    runtests=false
-  elif [[ "$1" == "--nobuild" ]]
-  then
-    nobuild=true
-  elif [[ "$1" == "--coverage" ]]
-  then
-    runcoverage=true
-    install_dotcover
-    mkdir -p coverage
-  else
-    apis+=($1)
-  fi
-  shift
-done
+echo Packing...
+rm -rf nupkg
+dotnet pack -nologo -v quiet Google.Cloud.EntityFrameworkCore.Spanner -o $PWD/nupkg
 
-# Build and test the tools, but only on Windows
-[[ "$OS" == "Windows_NT" ]] && tools="tools" || tools=""
-
-if [[ "$nobuild" == "true" ]]
-then
-  echo "APIs that would be built:"
-  for api in ${apis[*]}
-  do
-    echo "$api"
-  done
-  exit 0
-fi
-
-# TODO: Do we need these?
-# First build the analyzers, for use in everything else.
-#log_build_action "(Start) build.sh"
-#log_build_action "Building analyzers"
-
-#dotnet publish -nologo -clp:NoSummary -v quiet -c Release -f netstandard2.0 tools/Google.Cloud.Tools.Analyzers
-
-# Then build the requested APIs, working out the test projects as we go.
-> AllTests.txt
-for api in ${apis[*]}
-do
-  apidir=$api
-
-  log_build_action "Building $apidir"
-  dotnet build -nologo -clp:NoSummary -v quiet -c Release $apidir
-
-  # On Linux, we don't have desktop .NET, so any projects which only
-  # support desktop .NET are going to be broken. Just don't add them.
-  for testproject in $apidir.Tests/*.csproj
-  do
-    if [[ "$OS" == "Windows_NT" ]] || ! grep -q -E '>net[0-9]+<' $testproject
-    then
-      echo "$testproject" >> AllTests.txt
-    fi
-  done
-  
-  # If we're not going to test the desktop .NET builds, let's remove them
-  # entirely. This saves a huge amount of disk space, as the desktop framework
-  # builds include copies of gRPC.
-  if [[ ! "$OS" == "Windows_NT" ]]
-  then
-    rm -rf $apidir/bin/Release/net[0-9]*
-  fi
-done
-
-if [[ "$runtests" = true ]]
-then
-  log_build_action "(Start) Unit tests"
-  # Could use xargs, but this is more flexible
-  while read testproject
-  do
-    testdir=$(dirname $testproject)
-    log_build_action "Testing $testdir"
-    if [[ "$runcoverage" = true && -f "$testdir/coverage.xml" ]]
-    then
-      echo "(Running with coverage)"
-      (cd "$testdir"; $DOTCOVER cover "coverage.xml" --ReturnTargetExitCode)
-    else
-      dotnet test -nologo -c Release --no-build $testproject
-    fi
-  done < AllTests.txt
-  log_build_action "(End) Unit tests"
-fi
-
-log_build_action "(End) build.sh"
+echo Created packages:
+ls nupkg

--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -1,93 +1,18 @@
 #!/bin/bash
 
-# Script to perform a release build for all APIs tagged at
-# a specific commit. A single argument is required: the commit to use.
-
-# The repo is cloned into a fresh "releasebuild" directory.
-
 set -e
 
-# Additional arguments:
-# --rebuild_docs: Just build the projects and docs, don't create nuget packages.
-#                 Also, use the latest to pick up new docs changes rather than
-#                 the commit of the tag.
-# --skip_tests: Skip the integration tests
-# --ssh: Use SSH to clone GitHub repos
-rebuild_docs=false
-run_tests=true
-clone_path_prefix="https://github.com/"
-commit=
-while (( "$#" )); do
-  if [[ "$1" == "--rebuild_docs" ]]
-  then
-    rebuild_docs=true
-  elif [[ "$1" == "--skip_tests" ]]
-  then
-    run_tests=false
-  elif [[ "$1" == "--ssh" ]]
-  then
-    clone_path_prefix="git@github.com:"
-  else
-    commit=$1
-  fi
-  shift
-done
-
-if [ -z "$commit" ]
+if [[ -z "$1" ]]
 then
-  echo "Please specify a commit hash"
+  echo "Please specify the release tag"
   exit 1
 fi
 
-# Do everything from the repository root for sanity.
-cd $(dirname $0)
+rm -rf tmp
+mkdir tmp
 
-rm -rf releasebuild
-git clone ${clone_path_prefix}googleapis/dotnet-spanner-entity-framework.git releasebuild -c core.autocrlf=input --recursive
-cd releasebuild
+git clone https://github.com/googleapis/dotnet-spanner-entity-framework.git \
+  --depth 1 -b $1 --recursive tmp/release
 
-# See b/381899554
-git config --global --add safe.directory C:/tmpfs/src/github/dotnet-spanner-entity-framework
-
-# Make sure the package is deterministic. We don't do this for local builds,
-# but it makes debugging work more reliably for PDBs in packages.
-export DeterministicSourcePaths=true
-
-if [[ "$rebuild_docs" = true ]]
-then
-  git checkout master
-else
-  git checkout $commit
-fi
-
-# Turn the multi-line output of git tag --points-at into space-separated list of projects
-projects="Google.Cloud.EntityFrameworkCore.Spanner"
-
-./build.sh $projects
-
-# TODO: Figure out how to get the integration tests to run.
-
-if [[ "$rebuild_docs" = false ]]
-then
-  for project in $projects
-  do
-    # Don't pack the whole solution - just the project. (Avoids packing dependent
-    # projects such as Google.LongRunning.)
-    dotnet pack --no-build --no-restore -o $PWD/nuget -c Release $project
-  done
-fi
-
-# TODO: Use builddocs.sh to build docs.
-
-echo "Release build and docs complete for the following projects:"
-for project in $projects
-do
-  echo "- ${project}"
-done
-if [[ "$rebuild_docs" = false ]]
-then
-  echo "- Push packages to nuget:"
-  echo "  - cd releasebuild/nuget"
-  echo "  - Remove any packages you don't want to push"
-  echo "  - for pkg in *.nupkg; do dotnet nuget push -s https://api.nuget.org/v3/index.json -k API_KEY_HERE \$pkg; done"
-fi
+cd tmp/release
+./build.sh


### PR DESCRIPTION
The existing scripts had been copied from google-cloud-dotnet and had a lot of unused code for dealing with the release of multiple packages, etc. These are similar to the ones in google-cloudevents-dotnet which is also a single package repository.

See b/393190949