### PR TITLE
fix: migration default value should be wrapped in parentheses

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -209,7 +209,7 @@ CONSTRAINT `Chk_Title_Length_Equal` CHECK (CHARACTER_LENGTH(Title) > 0),
         }
 
         [Fact]
-        public virtual void AddColumnOperation_with_defaultValue()
+        public virtual void AddColumnOperation_with_defaultValueSql()
         {
             Generate(
                 new AddColumnOperation
@@ -222,6 +222,23 @@ CONSTRAINT `Chk_Title_Length_Equal` CHECK (CHARACTER_LENGTH(Title) > 0),
                     DefaultValueSql = "CURRENT_TIMESTAMP"
                 });
             AssertSql(@"ALTER TABLE `Album` ADD `CreatedDate` TIMESTAMP NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+");
+        }
+
+        [Fact]
+        public virtual void AddColumnOperation_with_defaultValue()
+        {
+            Generate(
+                new AddColumnOperation
+                {
+                    Table = "Album",
+                    Name = "Price",
+                    ClrType = typeof(DateTime),
+                    ColumnType = "NUMERIC",
+                    IsNullable = false,
+                    DefaultValueSql = "10"
+                });
+            AssertSql(@"ALTER TABLE `Album` ADD `Price` NUMERIC NOT NULL DEFAULT (10)
 ");
         }
 
@@ -544,7 +561,7 @@ WHERE `SingerId` = 4;
         }
 
         [Fact]
-        public virtual void AlterColumnOperation_set_default_value()
+        public virtual void AlterColumnOperation_set_default_value_sql()
         {
             Generate(
                 new AlterColumnOperation
@@ -555,6 +572,20 @@ WHERE `SingerId` = 4;
                     DefaultValueSql = "'London'"
                 });
             AssertSql(@"ALTER TABLE `Singers` ALTER COLUMN `Location` STRING(MAX) NOT NULL DEFAULT ('London')");
+        }
+
+        [Fact]
+        public virtual void AlterColumnOperation_set_default_value()
+        {
+            Generate(
+                new AlterColumnOperation
+                {
+                    Table = "Singers",
+                    Name = "Location",
+                    ClrType = typeof(string),
+                    DefaultValue = "London"
+                });
+            AssertSql(@"ALTER TABLE `Singers` ALTER COLUMN `Location` STRING(MAX) NOT NULL DEFAULT ('''London''')");
         }
 
         [Fact]

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -532,5 +532,25 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Migrations
         {
             throw new NotSupportedException("Cloud Spanner does not support dropping a primary key. All tables must always have a primary key.");
         }
+
+        protected override void DefaultValue(object defaultValue, string defaultValueSql, string columnType, MigrationCommandListBuilder builder)
+        {
+            if (defaultValueSql != null)
+            {
+                base.DefaultValue(defaultValue, defaultValueSql, columnType, builder);
+            }
+            else if (defaultValue != null)
+            {
+                var typeMapping = (columnType != null
+                        ? Dependencies.TypeMappingSource.FindMapping(defaultValue.GetType(), columnType)
+                        : null)
+                    ?? Dependencies.TypeMappingSource.GetMappingForValue(defaultValue);
+
+                builder
+                    .Append(" DEFAULT (")
+                    .Append(typeMapping.GenerateSqlLiteral(defaultValue))
+                    .Append(")");
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #510

- [x] Tests pass
- [ N/A] Appropriate changes to README are included in PR

Adds parentheses to default values in migrations. I'm not sure about the triple quoting of string literals (see AlterColumnOperation_set_default_value test), but that is the existing implementation of GenerateSqlLiteral for strings