### PR TITLE
build: remove renovate config for v3.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "baseBranches": ["main", "v3.1"],
+  "baseBranches": ["main"],
   "semanticCommitType": "deps",
   "semanticCommitScope": "",
   "extends": [


### PR DESCRIPTION
Remove the renovate configuration for the 3.1 branch, as Entity Framework Core 3.1 is no longer supported. See https://learn.microsoft.com/en-us/ef/core/what-is-new/ for the supported versions.