### PR TITLE
fix: identity annotations on properties were not generated

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/Google.Cloud.EntityFrameworkCore.Spanner.Samples.csproj
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/Google.Cloud.EntityFrameworkCore.Spanner.Samples.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>SampleRunner</AssemblyName>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +24,10 @@
 
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.17">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleModel/SpannerSampleDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Samples/SampleModel/SpannerSampleDbContext.cs
@@ -29,6 +29,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples.SampleModel
     {
         private readonly string _connectionString;
 
+        public SpannerSampleDbContext()
+        {
+            _connectionString = "DataSource=projects/my-project/instances/my-instance/database/my-database";
+        }
+
         /// <summary>
         /// Creates a <see cref="DbContext"/> that connects to a Cloud Spanner database using the sample data model.
         /// </summary>
@@ -87,6 +92,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Samples.SampleModel
                 entity
                     .InterleaveInParent(typeof(Album), OnDelete.Cascade)
                     .HasKey(entity => new { entity.AlbumId, entity.TrackId });
+                entity.Property(e => e.TrackId)
+                    .HasAnnotation(SpannerAnnotationNames.Identity, SpannerIdentityOptionsData.Default.Serialize())
+                    .ValueGeneratedOnAdd();
                 // Adding HasDefaultValueSql to the property makes sure that Entity Framework does
                 // not include the column in an INSERT statement if the property does not have an
                 // explicit value.

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/Internal/SpannerRelationalAnnotationProvider.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/Internal/SpannerRelationalAnnotationProvider.cs
@@ -58,6 +58,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Migrations.Internal
                 {
                     yield return commitTimestampAnnotation;
                 }
+                var identityAnnotation = mapping.Property.FindAnnotation(SpannerAnnotationNames.Identity);
+                if (identityAnnotation != null)
+                {
+                    yield return identityAnnotation;
+                }
             }
         }
         


### PR DESCRIPTION
Adding an annotation for identity generation on a property did not result in an annotation being added to the column definition when a migration was generated.
