### PR TITLE
fix: add ON DELETE CASCADE for foreign keys

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/GenerateCreateScriptTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/GenerateCreateScriptTest.cs
@@ -138,7 +138,7 @@ CREATE TABLE `Concerts` (
     `StartTime` TIMESTAMP NOT NULL,
     `SingerId` INT64 NOT NULL,
     `Title` STRING(200),
- CONSTRAINT `FK_Concerts_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`),
+ CONSTRAINT `FK_Concerts_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`) ON DELETE CASCADE,
  CONSTRAINT `FK_Concerts_Venues` FOREIGN KEY (`VenueCode`) REFERENCES `Venues` (`Code`),
 )PRIMARY KEY (`VenueCode`, `StartTime`, `SingerId`)
 
@@ -248,7 +248,7 @@ CREATE TABLE `Concerts` (
     `StartTime` TIMESTAMP NOT NULL,
     `SingerId` INT64 NOT NULL,
     `Title` STRING(200),
- CONSTRAINT `FK_Concerts_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`),
+ CONSTRAINT `FK_Concerts_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`) ON DELETE CASCADE,
  CONSTRAINT `FK_Concerts_Venues` FOREIGN KEY (`VenueCode`) REFERENCES `Venues` (`Code`),
 )PRIMARY KEY (`VenueCode`, `StartTime`, `SingerId`)
 
@@ -358,7 +358,7 @@ CREATE TABLE `Concerts` (
     `StartTime` TIMESTAMP NOT NULL,
     `SingerId` INT64 NOT NULL,
     `Title` STRING(200),
- CONSTRAINT `FK_Concerts_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`),
+ CONSTRAINT `FK_Concerts_Singers` FOREIGN KEY (`SingerId`) REFERENCES `Singers` (`SingerId`) ON DELETE CASCADE,
  CONSTRAINT `FK_Concerts_Venues` FOREIGN KEY (`VenueCode`) REFERENCES `Venues` (`Code`),
 )PRIMARY KEY (`VenueCode`, `StartTime`, `SingerId`)
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/Migrations/20210309110233_Initial.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/Migrations/20210309110233_Initial.cs
@@ -131,7 +131,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.MigrationTests.Migratio
                         column: x => x.SingerId,
                         principalTable: "Singers",
                         principalColumn: "SingerId",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_Concerts_Venues",
                         column: x => x.VenueCode,

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/Models/SpannerMigrationSampleDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/MigrationTests/Models/SpannerMigrationSampleDbContext.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.MigrationTests.Models
                 entity.HasOne(d => d.Singer)
                     .WithMany(p => p.Concerts)
                     .HasForeignKey(d => d.SingerId)
-                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("FK_Concerts_Singers");
 
                 entity.HasOne(d => d.VenueCodeNavigation)

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Migrations/SpannerMigrationSqlGeneratorTest.cs
@@ -248,7 +248,7 @@ CONSTRAINT `Chk_Title_Length_Equal` CHECK (CHARACTER_LENGTH(Title) > 0),
         public override void AddForeignKeyOperation_with_name()
         {
             base.AddForeignKeyOperation_with_name();
-            AssertSql(@"ALTER TABLE `Album` ADD  CONSTRAINT `FK_Album_Singer` FOREIGN KEY (`SingerId`) REFERENCES `Singer` (`SingerId`)
+            AssertSql(@"ALTER TABLE `Album` ADD  CONSTRAINT `FK_Album_Singer` FOREIGN KEY (`SingerId`) REFERENCES `Singer` (`SingerId`) ON DELETE CASCADE
 ");
         }
 

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Migrations/SpannerMigrationsSqlGenerator.cs
@@ -320,6 +320,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Migrations
                 .Append(" (")
                 .Append(ColumnList(operation.PrincipalColumns))
                 .Append(")");
+            if (operation.OnDelete == ReferentialAction.Cascade)
+            {
+                builder.Append(" ON DELETE CASCADE");
+            }
         }
 
         private static string GetCorrectedColumnType(string columnType, int? maxLength)


### PR DESCRIPTION
Spanner now supports ON DELETE CASCADE actions for foreign keys. This was however not included in the generated migration script is this had been specified in the model or migration.

Fixes #583
