### PR TITLE
feat: allow string to be mapped to JSON columns

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/SpannerSampleDbContext.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/SpannerSampleDbContext.cs
@@ -215,7 +215,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.Model
                 });
             });
             
-            modelBuilder.Entity<TicketSales>();
+            modelBuilder.Entity<TicketSales>(entity =>
+            {
+                entity.Property(e => e.Receipt).HasColumnType("JSON");
+            });
         }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/TicketSales.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Model/TicketSales.cs
@@ -19,4 +19,9 @@ public class TicketSales
     public long Id { get; set; }
 
     public string CustomerName { get; set; }
+    
+    /// <summary>
+    /// Receipt is stored as a JSON column in the database.
+    /// </summary>
+    public string Receipt { get; set; }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkUsingMutationsMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkUsingMutationsMockServerTests.cs
@@ -782,9 +782,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             await using var db = new MockServerSampleDbContextUsingMutations(ConnectionString);
             var transaction = await db.Database.BeginTransactionAsync();
             db.TicketSales.AddRange([
-                new TicketSales { CustomerName = "New Customer1"},
-                new TicketSales { CustomerName = "New Customer2"},
-                new TicketSales { CustomerName = "New Customer3"},
+                new TicketSales { CustomerName = "New Customer1", Receipt = "{\"Purchase Date\": \"2025-09-01\"}"},
+                new TicketSales { CustomerName = "New Customer2", Receipt = "{\"Purchase Date\": \"2025-09-01\"}"},
+                new TicketSales { CustomerName = "New Customer3", Receipt = "{\"Purchase Date\": \"2025-09-01\"}"},
             ]);
             var updateCount = await db.SaveChangesAsync();
             await transaction.CommitAsync();
@@ -804,10 +804,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         private static void ValidateInsertTicketSaleMutation(Mutation mutation, int index)
         {
             Assert.Equal(Mutation.OperationOneofCase.Insert, mutation.OperationCase);
-            Assert.Single(mutation.Insert.Columns);
+            Assert.Equal(2, mutation.Insert.Columns.Count);
             Assert.Single(mutation.Insert.Values);
             Assert.Equal("CustomerName", mutation.Insert.Columns[0]);
+            Assert.Equal("Receipt", mutation.Insert.Columns[1]);
             Assert.Equal($"New Customer{index}", mutation.Insert.Values[0].Values[0].StringValue);
+            Assert.Equal("{\"Purchase Date\": \"2025-09-01\"}", mutation.Insert.Values[0].Values[1].StringValue);
         }
 
         private string AddFindSingerResult(string sql)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerStringTypeMapping.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerStringTypeMapping.cs
@@ -32,23 +32,20 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             int? size = null,
             bool fixedLength = false,
             SpannerDbType sqlDbType = null,
+            DbType? dbType = null,
             StoreTypePostfix? storeTypePostfix = null)
             : this(
                 new RelationalTypeMappingParameters(
                     new CoreTypeMappingParameters(typeof(string), jsonValueReaderWriter: JsonStringReaderWriter.Instance),
                     storeType,
                     storeTypePostfix ?? StoreTypePostfix.Size,
-                    GetDbType(unicode, fixedLength),
+                    dbType ?? System.Data.DbType.String,
                     unicode,
                     size,
                     fixedLength),
                 sqlDbType)
         {
         }
-
-        private static DbType? GetDbType(bool unicode, bool fixedLength) => unicode
-            ? (fixedLength ? System.Data.DbType.String : (DbType?)null)
-            : System.Data.DbType.AnsiString;
 
         protected SpannerStringTypeMapping(RelationalTypeMappingParameters parameters, SpannerDbType sqlDbType)
             : base(parameters)
@@ -71,10 +68,6 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             {
                 sqlParameter.SpannerDbType = _sqlDbType;
             }
-
-            parameter.Size = value == null || value == DBNull.Value || length != null && length <= _maxSpecificSize
-                ? _maxSpecificSize
-                : 0;
         }
 
         protected override string GenerateNonNullSqlLiteral(object value)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMappingSource.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMappingSource.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore.Storage.Json;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 {
@@ -70,6 +71,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         private static readonly SpannerJsonTypeMapping s_json = new SpannerJsonTypeMapping();
         private static readonly SpannerStructuralJsonTypeMapping s_structuralJson = new SpannerStructuralJsonTypeMapping("json");
+        private static readonly SpannerStringTypeMapping s_jsonAsString = new ("JSON", sqlDbType: SpannerDbType.Json, dbType: DbType.Object);
 
         private static readonly SpannerGuidTypeMapping s_guid
             = new SpannerGuidTypeMapping("STRING(36)", DbType.String);
@@ -316,6 +318,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
             if (storeTypeName != null)
             {
+                if (storeTypeName.Equals("JSON", StringComparison.InvariantCultureIgnoreCase) &&
+                    clrType == typeof(string))
+                {
+                    return s_jsonAsString;
+                }
+                
                 if (_storeTypeMappings.TryGetValue(storeTypeName, out var mapping)
                     || _storeTypeMappings.TryGetValue(storeTypeNameBase, out mapping))
                 {


### PR DESCRIPTION
Adding a property to an entity with Clr type `string` and ColumnType JSON will now use a type mapping that allows the value to be stored in the database as JSON.

That is, the following is now supported:

```csharp
public class TicketSales
{
    public long Id { get; set; }

    public string CustomerName { get; set; }

    /// <summary>
    /// Receipt is stored as a JSON column in the database.
    /// </summary>
    public string Receipt { get; set; }
}

// ... In the DbContext ...

modelBuilder.Entity<TicketSales>(entity =>
{
    entity.Property(e => e.Receipt).HasColumnType("JSON");
});

```

Fixes #592
