### PR TITLE
fix: session leak for empty transaction with tag

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkSessionLeakMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkSessionLeakMockServerTests.cs
@@ -2201,21 +2201,43 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         }
 
         [Fact]
-        public async Task OnlyDisposingReadOnlyTransactionWithoutCommitting_LeaksSession()
+        public async Task OnlyDisposingReadOnlyTransactionWithoutCommitting_DoesNotLeakSession()
         {
             AddFindSingerResult($"SELECT `s`.`SingerId`, `s`.`BirthDate`, `s`.`FirstName`, `s`.`FullName`," +
                                 $" `s`.`LastName`, `s`.`Picture`{Environment.NewLine}FROM `Singers` AS `s`{Environment.NewLine}" +
                                 $"WHERE `s`.`SingerId` = @__p_0{Environment.NewLine}LIMIT 1");
 
-            var exception = await Assert.ThrowsAsync<SpannerException>(() => Repeat(async () =>
+            await Repeat(async () =>
             {
                 using var db = CreateContext();
                 // NOTE: This transaction is being disposed, but it's not being committed or rolled back.
                 using var transaction = await db.Database.BeginReadOnlyTransactionAsync();
                 Assert.NotNull(await db.Singers.FindAsync(1L));
                 // Note: No Commit or Rollback
-            }));
-            Assert.Equal(ErrorCode.ResourceExhausted, exception.ErrorCode);
+            });
+        }
+
+        [Fact]
+        public async Task EmptyReadWriteTransactionWithTagDoesNotLeakSession()
+        {
+            await using var db = CreateContext();
+            await Repeat(async () =>
+            {
+                // Execute an empty read/write transaction with a tag.
+                await using var transaction = await db.Database.BeginTransactionAsync("some_tag");
+                await transaction.CommitAsync();
+            });
+        }
+
+        [Fact]
+        public async Task StartingTwoTransactionsOnSameConnectionFailsAndDoesNotLeakSession()
+        {
+            await using var db = CreateContext();
+            await Repeat(async () =>
+            {
+                await using var transaction1 = await db.Database.BeginTransactionAsync("some_tag1");
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await db.Database.BeginTransactionAsync("some_tag2"));
+            });
         }
 
         private void AddFindSingerResult(string sql)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerDatabaseFacadeExtensions.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Extensions/SpannerDatabaseFacadeExtensions.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Extensions
             var transactionManager = databaseFacade.GetService<IDbContextTransactionManager>();
             if (transactionManager is SpannerRelationalConnection spannerRelationalConnection)
             {
-                return spannerRelationalConnection.BeginTransactionAsync(tag);
+                return spannerRelationalConnection.BeginTransactionAsync(tag, cancellationToken);
             }
             throw new InvalidOperationException("Transaction tags can only be used with Spanner databases");
         }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRelationalConnection.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRelationalConnection.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Data;
 using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Infrastructure;
@@ -23,6 +24,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Api.Gax;
 
 namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 {
@@ -75,7 +77,21 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// <param name="tag">The transaction tag to use for the transaction</param>
         /// <returns>A read/write transaction that uses the given isolation level and tag</returns>
         public IDbContextTransaction BeginTransaction(IsolationLevel isolationLevel, string tag)
-            => UseTransaction(Connection.BeginTransaction(isolationLevel, tag));
+        {
+            GaxPreconditions.CheckState(CurrentTransaction == null, "This connection already has a transaction");
+            var transaction = Connection.BeginTransaction(isolationLevel, tag);
+            CurrentTransaction = CreateRelationalTransaction(transaction, Guid.NewGuid(), transactionOwned: true);
+            return CurrentTransaction;
+        }
+        
+        private IDbContextTransaction CreateRelationalTransaction(DbTransaction transaction, Guid transactionId, bool transactionOwned)
+            => CurrentTransaction
+                = Dependencies.RelationalTransactionFactory.Create(
+                    this,
+                    transaction,
+                    transactionId,
+                    Dependencies.TransactionLogger,
+                    transactionOwned: transactionOwned);
 
         /// <summary>
         /// Begins a read/write transaction on this connection with the given transaction tag.
@@ -94,7 +110,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>A read/write transaction that uses the given isolation level and tag</returns>
         public async Task<IDbContextTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, string tag, CancellationToken cancellationToken = default)
-            => await UseTransactionAsync(await Connection.BeginTransactionAsync(isolationLevel, tag, cancellationToken), cancellationToken);
+        {
+            GaxPreconditions.CheckState(CurrentTransaction == null, "This connection already has a transaction");
+            var transaction = await Connection.BeginTransactionAsync(isolationLevel, tag,  cancellationToken).ConfigureAwait(false);
+            CurrentTransaction = CreateRelationalTransaction(transaction, Guid.NewGuid(), transactionOwned: true);
+            return CurrentTransaction;
+        }
 
         /// <summary>
         /// Begins a read-only transaction on this connection.
@@ -107,8 +128,13 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// </summary>
         /// <param name="timestampBound">The read timestamp to use for the transaction</param>
         /// <returns>A read-only transaction that uses the specified <see cref="TimestampBound"/></returns>
-        public IDbContextTransaction BeginReadOnlyTransaction(TimestampBound timestampBound) =>
-            UseTransaction(Connection.BeginReadOnlyTransaction(timestampBound));
+        public IDbContextTransaction BeginReadOnlyTransaction(TimestampBound timestampBound)
+        {
+            GaxPreconditions.CheckState(CurrentTransaction == null, "This connection already has a transaction");
+            var transaction = Connection.BeginReadOnlyTransaction(timestampBound);
+            CurrentTransaction = CreateRelationalTransaction(transaction, Guid.NewGuid(), transactionOwned: true);
+            return CurrentTransaction;
+        }
 
         /// <summary>
         /// Begins a read-only transaction on this connection.
@@ -122,8 +148,13 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// <param name="timestampBound">The read timestamp to use for the transaction</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>A read-only transaction that uses the specified <see cref="TimestampBound"/></returns>
-        public async Task<IDbContextTransaction> BeginReadOnlyTransactionAsync(TimestampBound timestampBound, CancellationToken cancellationToken = default) =>
-            await UseTransactionAsync(await Connection.BeginReadOnlyTransactionAsync(timestampBound, cancellationToken));
+        public async Task<IDbContextTransaction> BeginReadOnlyTransactionAsync(TimestampBound timestampBound, CancellationToken cancellationToken = default)
+        {
+            GaxPreconditions.CheckState(CurrentTransaction == null, "This connection already has a transaction");
+            var transaction = await Connection.BeginReadOnlyTransactionAsync(timestampBound, cancellationToken).ConfigureAwait(false);
+            CurrentTransaction = CreateRelationalTransaction(transaction, Guid.NewGuid(), transactionOwned: true);
+            return CurrentTransaction;
+        }
 
         /// <summary>
         /// Creates a connection to the Cloud Spanner instance that is referenced by <see cref="RelationalConnection.ConnectionString"/>.


### PR DESCRIPTION
Executing an empty read/write transaction with a tag would cause a session leak, as the transaction was marked as not owned.

Fixes #635
