### PR TITLE
chore: use actor as committer for code sync

### DIFF
--- a/.github/workflows/sync-spannerlib-code.yml
+++ b/.github/workflows/sync-spannerlib-code.yml
@@ -33,3 +33,4 @@ jobs:
           title: "chore: sync SpannerLib code"
           body: "Update the ADO.NET driver with the latest SpannerLib code."
           base: main
+          committer: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
Use the GitHub actor as the committer for code sync to prevent problems with the CLA check.