### PR TITLE
fix: float32 was mapped to float64 when mapped by name

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/SpannerTypeMapperTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/SpannerTypeMapperTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,6 +85,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Storage
         public void Does_float_mapping()
         {
             Assert.Equal("FLOAT32", GetTypeMapping(typeof(float)).StoreType);
+        }
+
+        [Fact]
+        public void Can_map_float32_by_name()
+        {
+            var mapping = CreateTypeMapper().FindMapping("FLOAT32");
+            Assert.NotNull(mapping);
+            Assert.Equal(typeof(float), mapping.ClrType);
+            Assert.Equal("FLOAT32", mapping.StoreType);
         }
 
         [Fact]

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/SpannerTypeMapperTest.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/SpannerTypeMapperTest.cs
@@ -87,13 +87,16 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests.Storage
             Assert.Equal("FLOAT32", GetTypeMapping(typeof(float)).StoreType);
         }
 
-        [Fact]
-        public void Can_map_float32_by_name()
+        [Theory]
+        [InlineData("FLOAT32")]
+        [InlineData("float32")]
+        [InlineData("Float32")]
+        public void Can_map_float32_by_name(string typeName)
         {
-            var mapping = CreateTypeMapper().FindMapping("FLOAT32");
+            var mapping = CreateTypeMapper().FindMapping(typeName);
             Assert.NotNull(mapping);
             Assert.Equal(typeof(float), mapping.ClrType);
-            Assert.Equal("FLOAT32", mapping.StoreType);
+            Assert.Equal(typeName, mapping.StoreType);
         }
 
         [Fact]

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMappingSource.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerTypeMappingSource.cs
@@ -269,12 +269,12 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                     {typeof(List<byte[]>), s_byteList},
                 };
 
-            _storeTypeMappings = new Dictionary<string, RelationalTypeMapping>
+            _storeTypeMappings = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
             {
                 {SpannerDbType.Bool.ToString(), s_bool},
                 {SpannerDbType.Bytes.ToString(), s_bytes},
                 {SpannerDbType.Date.ToString(), s_date},
-                {SpannerDbType.Float32.ToString(), s_double},
+                {SpannerDbType.Float32.ToString(), s_float},
                 {SpannerDbType.Float64.ToString(), s_double},
                 {SpannerDbType.Int64.ToString(), s_long},
                 {SpannerDbType.Timestamp.ToString(), s_datetime},
@@ -293,7 +293,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 {"ARRAY<JSON>", s_jsonList}
             };
 
-            _arrayTypeMappings = new Dictionary<string, RelationalTypeMapping>
+            _arrayTypeMappings = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
             {
                 {"ARRAY<BOOL>", s_nullableBoolArray},
                 {"ARRAY<BYTES", s_byteArray},


### PR DESCRIPTION
If a float32 was mapped using the type name, then it would inadvertently be mapped to a float64 instead. This fix corrects that.

This change also makes the type name mapping case-insensitive.
