### PR TITLE
fix(ado.net): prevent swallowing of non-Spanner exceptions in async paths

### DIFF
--- a/spanner-ado-net/spanner-ado-net-tests/TransactionTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/TransactionTests.cs
@@ -829,4 +829,25 @@ public class TransactionTests : AbstractMockServerTests
         });
     }
 
+    [Test]
+    public async Task RollbackAsync_PropagatesException_IfConnectionIsClosed()
+    {
+        await using var connection = new SpannerConnection(ConnectionString);
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+        await connection.CloseAsync();
+
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await transaction.RollbackAsync());
+    }
+
+    [Test]
+    public async Task CommitAsync_PropagatesException_IfConnectionIsClosed()
+    {
+        await using var connection = new SpannerConnection(ConnectionString);
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+        await connection.CloseAsync();
+
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await transaction.CommitAsync());
+    }
 }

--- a/spanner-ado-net/spanner-ado-net/SpannerDbException.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerDbException.cs
@@ -34,29 +34,28 @@ public class SpannerDbException : DbException
         }
     }
     
-    internal static Task TranslateException(Task task)
+    internal static async Task TranslateException(Task task)
     {
-        return task.ContinueWith( t => 
-            {
-                if (t.IsFaulted && t.Exception.InnerException is SpannerException spannerException)
-                {
-                    throw TranslateException(spannerException);
-                }
-            },
-            TaskContinuationOptions.ExecuteSynchronously);
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (SpannerException exception)
+        {
+            throw TranslateException(exception);
+        }
     }
 
-    internal static Task<T> TranslateException<T>(Task<T> task)
+    internal static async Task<T> TranslateException<T>(Task<T> task)
     {
-        return task.ContinueWith( t => 
-            {
-                if (t.IsFaulted && t.Exception.InnerException is SpannerException spannerException)
-                {
-                    throw TranslateException(spannerException);
-                }
-                return t.Result;
-            },
-            TaskContinuationOptions.ExecuteSynchronously);
+        try
+        {
+            return await task.ConfigureAwait(false);
+        }
+        catch (SpannerException exception)
+        {
+            throw TranslateException(exception);
+        }
     }
 
     internal static Exception TranslateException(SpannerException exception)

--- a/spanner-ado-net/spanner-ado-net/SpannerDbException.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerDbException.cs
@@ -36,9 +36,21 @@ public class SpannerDbException : DbException
     
     internal static Task TranslateException(Task task)
     {
-        if (task.Status == TaskStatus.RanToCompletion)
+        if (task.IsCompleted)
         {
-            return Task.CompletedTask;
+            if (task.Status == TaskStatus.RanToCompletion)
+            {
+                return Task.CompletedTask;
+            }
+            if (task.IsFaulted)
+            {
+                var inner = task.Exception?.InnerException;
+                if (inner is SpannerException spannerException)
+                {
+                    return Task.FromException(TranslateException(spannerException));
+                }
+            }
+            return task;
         }
         return TranslateExceptionAsync(task);
 
@@ -57,8 +69,20 @@ public class SpannerDbException : DbException
 
     internal static Task<T> TranslateException<T>(Task<T> task)
     {
-        if (task.Status == TaskStatus.RanToCompletion)
+        if (task.IsCompleted)
         {
+            if (task.Status == TaskStatus.RanToCompletion)
+            {
+                return task;
+            }
+            if (task.IsFaulted)
+            {
+                var inner = task.Exception?.InnerException;
+                if (inner is SpannerException spannerException)
+                {
+                    return Task.FromException<T>(TranslateException(spannerException));
+                }
+            }
             return task;
         }
         return TranslateExceptionAsync(task);

--- a/spanner-ado-net/spanner-ado-net/SpannerDbException.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerDbException.cs
@@ -34,27 +34,45 @@ public class SpannerDbException : DbException
         }
     }
     
-    internal static async Task TranslateException(Task task)
+    internal static Task TranslateException(Task task)
     {
-        try
+        if (task.Status == TaskStatus.RanToCompletion)
         {
-            await task.ConfigureAwait(false);
+            return Task.CompletedTask;
         }
-        catch (SpannerException exception)
+        return TranslateExceptionAsync(task);
+
+        static async Task TranslateExceptionAsync(Task t)
         {
-            throw TranslateException(exception);
+            try
+            {
+                await t.ConfigureAwait(false);
+            }
+            catch (SpannerException exception)
+            {
+                throw TranslateException(exception);
+            }
         }
     }
 
-    internal static async Task<T> TranslateException<T>(Task<T> task)
+    internal static Task<T> TranslateException<T>(Task<T> task)
     {
-        try
+        if (task.Status == TaskStatus.RanToCompletion)
         {
-            return await task.ConfigureAwait(false);
+            return task;
         }
-        catch (SpannerException exception)
+        return TranslateExceptionAsync(task);
+
+        static async Task<T> TranslateExceptionAsync(Task<T> t)
         {
-            throw TranslateException(exception);
+            try
+            {
+                return await t.ConfigureAwait(false);
+            }
+            catch (SpannerException exception)
+            {
+                throw TranslateException(exception);
+            }
         }
     }
 

--- a/spanner-ado-net/spanner-ado-net/SpannerTransaction.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerTransaction.cs
@@ -123,7 +123,7 @@ public class SpannerTransaction : DbTransaction
 
     protected override void Dispose(bool disposing)
     {
-        if (!IsCompleted)
+        if (disposing && !IsCompleted)
         {
             try
             {
@@ -136,6 +136,7 @@ public class SpannerTransaction : DbTransaction
             }
         }
         _disposed = true;
+        base.Dispose(disposing);
     }
 
     public override async ValueTask DisposeAsync()
@@ -153,6 +154,7 @@ public class SpannerTransaction : DbTransaction
             }
         }
         _disposed = true;
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     private void CheckDisposed()

--- a/spanner-ado-net/spanner-ado-net/SpannerTransaction.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerTransaction.cs
@@ -125,8 +125,15 @@ public class SpannerTransaction : DbTransaction
     {
         if (!IsCompleted)
         {
-            // Do a shoot-and-forget rollback.
-            Rollback();
+            try
+            {
+                // Do a shoot-and-forget rollback.
+                Rollback();
+            }
+            catch
+            {
+                // Ignored during dispose
+            }
         }
         _disposed = true;
     }
@@ -135,8 +142,15 @@ public class SpannerTransaction : DbTransaction
     {
         if (!IsCompleted)
         {
-            // Do a shoot-and-forget rollback.
-            await RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                // Do a shoot-and-forget rollback.
+                await RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignored during dispose
+            }
         }
         _disposed = true;
     }


### PR DESCRIPTION
Refactors async task exception translators to use standard async/await rather than legacy `ContinueWith` task continuations. This ensures that all exceptions (e.g., ObjectDisposedException, RpcException, and cancellation errors) propagate up to the caller instead of being silently swallowed.

Additionally:
- Wraps best-effort rollback cleanups during SpannerTransaction disposal in try-catch blocks, preventing cleanup attempts on closed connections from throwing exceptions during dispose.
- Appends regression tests in TransactionTests.cs to verify proper exception propagation on closed connections for both CommitAsync and RollbackAsync.
