### PR TITLE
chore: remove potential RPC calls in finalizer calls

### DIFF
--- a/spanner-ado-net/spanner-ado-net-tests/ConnectionTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/ConnectionTests.cs
@@ -556,21 +556,42 @@ public class ConnectionTests : AbstractMockServerTests
         Assert.That(got, Is.EqualTo(value));
     }
 
-    [Test]
-    public async Task Finalizer_DoesNotThrow_IfConnectionIsClosed()
+    public class TestLibObject : Google.Cloud.SpannerLib.AbstractLibObject
     {
-        var connection = new SpannerConnection(ConnectionString);
-        await connection.OpenAsync();
-        
-        var libConnectionField = typeof(SpannerConnection).GetField("_libConnection", 
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        var libConnection = libConnectionField!.GetValue(connection);
+        public bool CloseLibObjectCalled { get; private set; }
 
-        await connection.CloseAsync();
+        public TestLibObject(long id) : base(null!, id)
+        {
+        }
 
-        var disposeMethod = typeof(Google.Cloud.SpannerLib.AbstractLibObject).GetMethod("Dispose", 
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        protected override void CloseLibObject()
+        {
+            CloseLibObjectCalled = true;
+        }
 
-        Assert.DoesNotThrow(() => disposeMethod!.Invoke(libConnection, new[] { (object)false }));
+        public void CallDispose(bool disposing)
+        {
+            Dispose(disposing);
+        }
+    }
+
+    [Test]
+    public void Finalizer_DoesNotCallCloseLibObject()
+    {
+        var testObj = new TestLibObject(id: 42);
+
+        testObj.CallDispose(disposing: false);
+
+        Assert.That(testObj.CloseLibObjectCalled, Is.False);
+    }
+
+    [Test]
+    public void Dispose_CallsCloseLibObject()
+    {
+        var testObj = new TestLibObject(id: 42);
+
+        testObj.CallDispose(disposing: true);
+
+        Assert.That(testObj.CloseLibObjectCalled, Is.True);
     }
 }

--- a/spanner-ado-net/spanner-ado-net-tests/ConnectionTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/ConnectionTests.cs
@@ -555,5 +555,22 @@ public class ConnectionTests : AbstractMockServerTests
         var got = await conn!.ExecuteScalarAsync(sql);
         Assert.That(got, Is.EqualTo(value));
     }
-    
+
+    [Test]
+    public async Task Finalizer_DoesNotThrow_IfConnectionIsClosed()
+    {
+        var connection = new SpannerConnection(ConnectionString);
+        await connection.OpenAsync();
+        
+        var libConnectionField = typeof(SpannerConnection).GetField("_libConnection", 
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var libConnection = libConnectionField!.GetValue(connection);
+
+        await connection.CloseAsync();
+
+        var disposeMethod = typeof(Google.Cloud.SpannerLib.AbstractLibObject).GetMethod("Dispose", 
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        Assert.DoesNotThrow(() => disposeMethod!.Invoke(libConnection, new[] { (object)false }));
+    }
 }

--- a/spanner-ado-net/spanner-ado-net-tests/ConnectionTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/ConnectionTests.cs
@@ -556,7 +556,7 @@ public class ConnectionTests : AbstractMockServerTests
         Assert.That(got, Is.EqualTo(value));
     }
 
-    public class TestLibObject : Google.Cloud.SpannerLib.AbstractLibObject
+    private class TestLibObject : Google.Cloud.SpannerLib.AbstractLibObject
     {
         public bool CloseLibObjectCalled { get; private set; }
 

--- a/spanner-ado-net/spanner-ado-net-tests/TransactionTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/TransactionTests.cs
@@ -861,7 +861,10 @@ public class TransactionTests : AbstractMockServerTests
         var initialRollbacks = Fixture.SpannerMock.Requests.OfType<RollbackRequest>().Count();
 
         var disposeMethod = typeof(SpannerTransaction).GetMethod("Dispose", 
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(bool) },
+            modifiers: null);
         disposeMethod!.Invoke(transaction, new[] { (object)false });
 
         var currentRollbacks = Fixture.SpannerMock.Requests.OfType<RollbackRequest>().Count();

--- a/spanner-ado-net/spanner-ado-net-tests/TransactionTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/TransactionTests.cs
@@ -850,4 +850,21 @@ public class TransactionTests : AbstractMockServerTests
 
         Assert.ThrowsAsync<ObjectDisposedException>(async () => await transaction.CommitAsync());
     }
+
+    [Test]
+    public async Task Finalizer_DoesNotExecuteRollback()
+    {
+        await using var connection = new SpannerConnection(ConnectionString);
+        await connection.OpenAsync();
+        var transaction = await connection.BeginTransactionAsync();
+        
+        var initialRollbacks = Fixture.SpannerMock.Requests.OfType<RollbackRequest>().Count();
+
+        var disposeMethod = typeof(SpannerTransaction).GetMethod("Dispose", 
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        disposeMethod!.Invoke(transaction, new[] { (object)false });
+
+        var currentRollbacks = Fixture.SpannerMock.Requests.OfType<RollbackRequest>().Count();
+        Assert.That(currentRollbacks, Is.EqualTo(initialRollbacks));
+    }
 }

--- a/spanner-ado-net/spanner-ado-net/SpannerLib/AbstractLibObject.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLib/AbstractLibObject.cs
@@ -42,11 +42,6 @@ public abstract class AbstractLibObject : IDisposable, IAsyncDisposable
         Id = id;
     } 
 
-    ~AbstractLibObject()
-    {
-        Dispose(false);
-    }
-
     protected void MarkDisposed()
     {
         _disposed = true;

--- a/spanner-ado-net/spanner-ado-net/SpannerLib/AbstractLibObject.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLib/AbstractLibObject.cs
@@ -78,7 +78,7 @@ public abstract class AbstractLibObject : IDisposable, IAsyncDisposable
         }
         try
         {
-            if (Id > 0)
+            if (disposing && Id > 0)
             {
                 CloseLibObject();
             }

--- a/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/GrpcLibSpanner.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/GrpcLibSpanner.cs
@@ -131,11 +131,17 @@ public sealed class GrpcLibSpanner : ISpannerLib
         }
         try
         {
-            foreach (var channel in _channels)
+            if (disposing)
             {
-                channel.Dispose();
+                if (_channels != null)
+                {
+                    foreach (var channel in _channels)
+                    {
+                        channel?.Dispose();
+                    }
+                }
+                _server?.Dispose();
             }
-            _server.Dispose();
         }
         finally
         {

--- a/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/GrpcLibSpanner.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/GrpcLibSpanner.cs
@@ -114,9 +114,7 @@ public sealed class GrpcLibSpanner : ISpannerLib
             _clients[i] = new V1.SpannerLib.SpannerLibClient(_channels[i]);
         }
     }
-    
-    ~GrpcLibSpanner() => Dispose(false);
-    
+
     public void Dispose()
     {
         Dispose(true);

--- a/spanner-ado-net/spanner-ado-net/SpannerLibGrpcServer/Server.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLibGrpcServer/Server.cs
@@ -243,8 +243,11 @@ public class Server : IDisposable
         }
         try
         {
-            Stop();
-            _process?.Dispose();
+            if (disposing)
+            {
+                Stop();
+                _process?.Dispose();
+            }
         }
         finally
         {

--- a/spanner-ado-net/spanner-ado-net/SpannerLibGrpcServer/Server.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLibGrpcServer/Server.cs
@@ -245,7 +245,14 @@ public class Server : IDisposable
         {
             if (disposing)
             {
-                Stop();
+                try
+                {
+                    Stop();
+                }
+                catch (Exception)
+                {
+                    // Ignore exceptions during shutdown/dispose
+                }
                 _process?.Dispose();
             }
         }


### PR DESCRIPTION
Remove potential RPC calls when finalizer calls are executed.
