### PR TITLE
fix(spanner-ado-net): prevent sync calls on async execution paths for DML stats

### DIFF
--- a/spanner-ado-net/spanner-ado-net-tests/CommandTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/CommandTests.cs
@@ -890,6 +890,108 @@ public class CommandTests : AbstractMockServerTests
         Assert.Throws<InvalidOperationException>(() => cmd.Transaction = tx);
     }
 
+    [Test]
+    public async Task TestExecuteNonQueryDml()
+    {
+        const string update = "UPDATE my_table SET int=int+1 WHERE int > 10";
+        Fixture.SpannerMock.AddOrUpdateStatementResult(update, StatementResult.CreateUpdateCount(5));
+
+        await using var connection = await OpenConnectionAsync();
+        
+        // Test Synchronous execution path
+        await using (var command = new SpannerCommand(update, connection))
+        {
+            var affected = command.ExecuteNonQuery();
+            Assert.That(affected, Is.EqualTo(5));
+        }
+
+        // Test Asynchronous execution path
+        await using (var command = new SpannerCommand(update, connection))
+        {
+            var affected = await command.ExecuteNonQueryAsync();
+            Assert.That(affected, Is.EqualTo(5));
+        }
+    }
+
+    [Test]
+    public async Task TestExecuteNonQueryMultiStatementDml()
+    {
+        const string update1 = "UPDATE my_table SET int=int+1 WHERE int > 10;";
+        const string update2 = "UPDATE my_table SET int=int+2 WHERE int > 20;";
+        Fixture.SpannerMock.AddOrUpdateStatementResult(update1, StatementResult.CreateUpdateCount(2));
+        Fixture.SpannerMock.AddOrUpdateStatementResult(update1[..^1], StatementResult.CreateUpdateCount(2));
+        Fixture.SpannerMock.AddOrUpdateStatementResult(update2, StatementResult.CreateUpdateCount(3));
+        Fixture.SpannerMock.AddOrUpdateStatementResult(update2[..^1], StatementResult.CreateUpdateCount(3));
+
+        await using var connection = await OpenConnectionAsync();
+
+        // 1. Test Synchronous execution path
+        await using (var command = new SpannerCommand(update1 + update2, connection))
+        {
+            var affected = command.ExecuteNonQuery();
+            Assert.That(affected, Is.EqualTo(5));
+        }
+
+        // 2. Test Asynchronous execution path
+        await using (var command = new SpannerCommand(update1 + update2, connection))
+        {
+            var affected = await command.ExecuteNonQueryAsync();
+            Assert.That(affected, Is.EqualTo(5));
+        }
+    }
+
+    [Test]
+    public async Task TestDmlWithReturningClause()
+    {
+        const string sql = "INSERT INTO my_table (id, name) VALUES (1, 'One') RETURNING id";
+        
+        // Mock a single-column result set that returns 5 rows and specifies 5 affected rows.
+        var type = new Google.Cloud.Spanner.V1.Type { Code = Google.Cloud.Spanner.V1.TypeCode.Int64 };
+        var mockResult = StatementResult.CreateSingleColumnResultSet(5L, type, "id", 1L, 2L, 3L, 4L, 5L);
+        Fixture.SpannerMock.AddOrUpdateStatementResult(sql, mockResult);
+
+        await using var connection = await OpenConnectionAsync();
+
+        // 1. Test Synchronous execution path
+        await using (var command = new SpannerCommand(sql, connection))
+        {
+            await using var reader = command.ExecuteReader();
+            
+            // Note: Due to a limitation in the Go SpannerLib library (which does not expose ResultSetStats
+            // for query iterators), the Go proxy is unable to retrieve the update count for DML statements with 
+            // a RETURNING clause. It therefore returns 0 affected rows.
+            Assert.That(reader.RecordsAffected, Is.EqualTo(0));
+
+            var rowCount = 0;
+            while (reader.Read())
+            {
+                rowCount++;
+                Assert.That(reader.GetInt64(0), Is.EqualTo((long)rowCount));
+            }
+            Assert.That(rowCount, Is.EqualTo(5));
+
+            Assert.That(reader.RecordsAffected, Is.EqualTo(0));
+        }
+
+        // 2. Test Asynchronous execution path
+        await using (var command = new SpannerCommand(sql, connection))
+        {
+            await using var reader = await command.ExecuteReaderAsync();
+            
+            Assert.That(reader.RecordsAffected, Is.EqualTo(0));
+
+            var rowCount = 0;
+            while (await reader.ReadAsync())
+            {
+                rowCount++;
+                Assert.That(reader.GetInt64(0), Is.EqualTo((long)rowCount));
+            }
+            Assert.That(rowCount, Is.EqualTo(5));
+
+            Assert.That(reader.RecordsAffected, Is.EqualTo(0));
+        }
+    }
+
     private void AddParameter(DbCommand command, string name, object? value)
     {
         var parameter = command.CreateParameter();

--- a/spanner-ado-net/spanner-ado-net-tests/RowsTests.cs
+++ b/spanner-ado-net/spanner-ado-net-tests/RowsTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Cloud.Spanner.V1;
+using Google.Cloud.SpannerLib;
+using Google.Protobuf.WellKnownTypes;
+using NUnit.Framework;
+
+namespace Google.Cloud.Spanner.DataProvider.Tests;
+
+[TestFixture]
+public class RowsTests
+{
+    [Test]
+    public async Task TestGetStatsAsyncDoesNotLeakSyncStatsCall()
+    {
+        var stubSpanner = new StubSpannerLib();
+        var pool = new Pool(stubSpanner, 1L);
+        var connection = new Connection(pool, 1L);
+        var rows = new Rows(connection, 1L, initMetadata: false);
+
+        // 1. Load stats asynchronously
+        var stats = await rows.GetStatsAsync();
+        Assert.That(stats, Is.Not.Null);
+        Assert.That(stats!.RowCountExact, Is.EqualTo(5L));
+        Assert.That(stubSpanner.StatsAsyncCalled, Is.True);
+        Assert.That(stubSpanner.StatsCalled, Is.False);
+
+        // 2. Execute Next() synchronously (simulating end of row iteration)
+        // This will call Spanner.Next (returns null) and should NOT trigger Spanner.Stats()
+        var nextRow = rows.Next();
+        Assert.That(nextRow, Is.Null);
+        
+        // Assert that the synchronous Spanner.Stats was NEVER called!
+        Assert.That(stubSpanner.StatsCalled, Is.False, "Synchronous Stats() was called during Next() causing sync-over-async block!");
+    }
+
+    [Test]
+    public void TestNextResultSetClearsStatsCache()
+    {
+        var stubSpanner = new StubSpannerLib();
+        var pool = new Pool(stubSpanner, 1L);
+        var connection = new Connection(pool, 1L);
+        var rows = new Rows(connection, 1L, initMetadata: false);
+
+        // 1. Fetch Stats synchronously
+        var stats1 = rows.UpdateCount;
+        Assert.That(stubSpanner.StatsCount, Is.EqualTo(1));
+        
+        // 2. Fetch Stats again - should return cached
+        var stats2 = rows.UpdateCount;
+        Assert.That(stubSpanner.StatsCount, Is.EqualTo(1));
+
+        // 3. Move to next result set (mock NextResultSet to return non-null metadata)
+        stubSpanner.NextResultSetMetadata = new ResultSetMetadata();
+        var hasNext = rows.NextResultSet();
+        Assert.That(hasNext, Is.True);
+
+        // 4. Fetch Stats again - cache should be cleared and it should call Stats() again
+        var stats3 = rows.UpdateCount;
+        Assert.That(stubSpanner.StatsCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task TestNextResultSetAsyncClearsStatsCache()
+    {
+        var stubSpanner = new StubSpannerLib();
+        var pool = new Pool(stubSpanner, 1L);
+        var connection = new Connection(pool, 1L);
+        var rows = new Rows(connection, 1L, initMetadata: false);
+
+        // 1. Fetch Stats asynchronously
+        var stats1 = await rows.GetStatsAsync();
+        Assert.That(stubSpanner.StatsAsyncCount, Is.EqualTo(1));
+        
+        // 2. Fetch Stats again - should return cached
+        var stats2 = await rows.GetStatsAsync();
+        Assert.That(stubSpanner.StatsAsyncCount, Is.EqualTo(1));
+
+        // 3. Move to next result set asynchronously
+        stubSpanner.NextResultSetMetadata = new ResultSetMetadata();
+        var hasNext = await rows.NextResultSetAsync();
+        Assert.That(hasNext, Is.True);
+
+        // 4. Fetch Stats again - cache should be cleared and it should call StatsAsync() again
+        var stats3 = await rows.GetStatsAsync();
+        Assert.That(stubSpanner.StatsAsyncCount, Is.EqualTo(2));
+    }
+
+    private class StubSpannerLib : ISpannerLib
+    {
+        public int StatsCount { get; private set; }
+        public int StatsAsyncCount { get; private set; }
+        public bool StatsCalled => StatsCount > 0;
+        public bool StatsAsyncCalled => StatsAsyncCount > 0;
+        public ResultSetMetadata? NextResultSetMetadata { get; set; }
+
+        public ResultSetStats? Stats(Rows rows)
+        {
+            StatsCount++;
+            return new ResultSetStats { RowCountExact = 5L };
+        }
+
+        public Task<ResultSetStats?> StatsAsync(Rows rows, CancellationToken cancellationToken = default)
+        {
+            StatsAsyncCount++;
+            return Task.FromResult<ResultSetStats?>(new ResultSetStats { RowCountExact = 5L });
+        }
+
+        public ListValue? Next(Rows rows, int numRows, ISpannerLib.RowEncoding encoding) => null;
+
+        public Task<ListValue?> NextAsync(Rows rows, int numRows, ISpannerLib.RowEncoding encoding, CancellationToken cancellationToken = default) =>
+            Task.FromResult<ListValue?>(null);
+
+        // Stub out other interface methods to satisfy compiler
+        public Pool CreatePool(string connectionString) => throw new NotImplementedException();
+        public void ClosePool(Pool pool) {}
+        public Connection CreateConnection(Pool pool) => throw new NotImplementedException();
+        public void CloseConnection(Connection connection) {}
+        public Task CloseConnectionAsync(Connection connection, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public CommitResponse? WriteMutations(Connection connection, BatchWriteRequest.Types.MutationGroup mutations) => throw new NotImplementedException();
+        public Task<CommitResponse?> WriteMutationsAsync(Connection connection, BatchWriteRequest.Types.MutationGroup mutations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Rows Execute(Connection connection, ExecuteSqlRequest statement, int prefetchRows = 0) => throw new NotImplementedException();
+        public Task<Rows> ExecuteAsync(Connection connection, ExecuteSqlRequest statement, int prefetchRows = 0, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public long[] ExecuteBatch(Connection connection, ExecuteBatchDmlRequest statements) => throw new NotImplementedException();
+        public Task<long[]> ExecuteBatchAsync(Connection connection, ExecuteBatchDmlRequest statements, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ResultSetMetadata? Metadata(Rows rows) => null;
+        public Task<ResultSetMetadata?> MetadataAsync(Rows rows, CancellationToken cancellationToken = default) => Task.FromResult<ResultSetMetadata?>(null);
+        public ResultSetMetadata? NextResultSet(Rows rows) => NextResultSetMetadata;
+        public Task<ResultSetMetadata?> NextResultSetAsync(Rows rows, CancellationToken cancellationToken = default) => Task.FromResult(NextResultSetMetadata);
+        public void CloseRows(Rows rows) {}
+        public Task CloseRowsAsync(Rows rows, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void BeginTransaction(Connection connection, TransactionOptions transactionOptions) {}
+        public Task BeginTransactionAsync(Connection connection, TransactionOptions transactionOptions, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public CommitResponse? Commit(Connection connection) => throw new NotImplementedException();
+        public Task<CommitResponse?> CommitAsync(Connection connection, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void Rollback(Connection connection) {}
+        public Task RollbackAsync(Connection connection, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void Dispose() {}
+    }
+}

--- a/spanner-ado-net/spanner-ado-net/SpannerLib/ISpannerLib.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLib/ISpannerLib.cs
@@ -221,6 +221,16 @@ public interface ISpannerLib : IDisposable
     public ResultSetStats? Stats(Rows rows);
 
     /// <summary>
+    /// Returns the ResultSetStats of a Rows object asynchronously. This object contains the update count of a DML statement
+    /// that was executed. This method can only be called once all data rows in the Rows object have been returned.
+    /// </summary>
+    /// <param name="rows">The Rows object to get the stats for</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>The ResultSetStats for the given Rows object</returns>
+    public Task<ResultSetStats?> StatsAsync(Rows rows, CancellationToken cancellationToken = default) =>
+        Task.FromResult(Stats(rows));
+
+    /// <summary>
     /// Returns the next numRows data rows from the given Rows object. The data is encoded using the specified
     /// RowEncoding. The default is an encoded protobuf ListValue containing as many values as there are columns in the
     /// query result, multiplied by the number of rows that were returned.

--- a/spanner-ado-net/spanner-ado-net/SpannerLib/Rows.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLib/Rows.cs
@@ -33,34 +33,74 @@ public class Rows : AbstractLibObject
     public virtual ResultSetMetadata? Metadata => _metadata ??= Spanner.Metadata(this);
 
     private Lazy<ResultSetStats?> _stats;
+    private ResultSetStats? _loadedStats;
+    private bool _statsLoaded;
 
     /// <summary>
     /// The ResultSetStats of the SQL statement. This is only available once all data rows have been read.
     /// </summary>
-    protected virtual ResultSetStats? Stats => _stats.Value;
+    protected virtual ResultSetStats? Stats
+    {
+        get
+        {
+            if (!_statsLoaded)
+            {
+                _loadedStats = _stats.Value;
+                _statsLoaded = true;
+            }
+            return _loadedStats;
+        }
+    }
+
+    /// <summary>
+    /// Returns the ResultSetStats of this Rows object asynchronously.
+    /// </summary>
+    public virtual async Task<ResultSetStats?> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        if (_statsLoaded)
+        {
+            return _loadedStats;
+        }
+        if (_stats.IsValueCreated)
+        {
+            _loadedStats = _stats.Value;
+            _statsLoaded = true;
+            return _loadedStats;
+        }
+        _loadedStats = await Spanner.StatsAsync(this, cancellationToken).ConfigureAwait(false);
+        _statsLoaded = true;
+        return _loadedStats;
+    }
+
+    private static long GetRowCount(ResultSetStats? stats)
+    {
+        if (stats == null)
+        {
+            return -1L;
+        }
+        if (stats.HasRowCountExact)
+        {
+            return stats.RowCountExact;
+        }
+        if (stats.HasRowCountLowerBound)
+        {
+            return stats.RowCountLowerBound;
+        }
+        return -1L;
+    }
 
     /// <summary>
     /// The update count of the SQL statement. This is only available once all data rows have been read.
     /// </summary>
-    public long UpdateCount
+    public long UpdateCount => GetRowCount(Stats);
+
+    /// <summary>
+    /// Gets the update count of the SQL statement asynchronously. This is only available once all data rows have been read.
+    /// </summary>
+    public async Task<long> GetUpdateCountAsync(CancellationToken cancellationToken = default)
     {
-        get
-        {
-            var stats = Stats;
-            if (stats == null)
-            {
-                return -1L;
-            }
-            if (stats.HasRowCountExact)
-            {
-                return stats.RowCountExact;
-            }
-            if (stats.HasRowCountLowerBound)
-            {
-                return stats.RowCountLowerBound;
-            }
-            return -1L;
-        }
+        var stats = await GetStatsAsync(cancellationToken).ConfigureAwait(false);
+        return GetRowCount(stats);
     }
     
     private bool _hasReadAllResults;
@@ -82,7 +122,7 @@ public class Rows : AbstractLibObject
     public virtual ListValue? Next()
     {
         var res = Spanner.Next(this, 1, ISpannerLib.RowEncoding.Proto);
-        if (res == null && !_stats.IsValueCreated)
+        if (res == null && !_statsLoaded && !_stats.IsValueCreated)
         {
             // initialize stats.
             _ = _stats.Value;
@@ -147,7 +187,7 @@ public class Rows : AbstractLibObject
         var hasUpdateCount = false;
         do
         {
-            var updateCount = UpdateCount;
+            var updateCount = await GetUpdateCountAsync(cancellationToken).ConfigureAwait(false);
             if (updateCount > -1)
             {
                 if (!hasUpdateCount)
@@ -196,6 +236,8 @@ public class Rows : AbstractLibObject
         }
         _metadata = metadata;
         _stats = new(() => Spanner.Stats(this));
+        _loadedStats = null;
+        _statsLoaded = false;
         return true;
     }
 

--- a/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/GrpcLibSpanner.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/GrpcLibSpanner.cs
@@ -355,6 +355,20 @@ public sealed class GrpcLibSpanner : ISpannerLib
         return TranslateException(() => Client.ResultSetStats(ToProto(rows)));
     }
 
+    public async Task<ResultSetStats?> StatsAsync(Rows rows, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await Client.ResultSetStatsAsync(ToProto(rows), cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RpcException exception)
+        {
+            throw SpannerException.ToSpannerException(exception);
+        }
+    }
+
+
+
     public ListValue? Next(Rows rows, int numRows, ISpannerLib.RowEncoding encoding)
     {
         var row = TranslateException(() =>Client.Next(new NextRequest

--- a/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/StreamingRows.cs
+++ b/spanner-ado-net/spanner-ado-net/SpannerLibGrpcImpl/StreamingRows.cs
@@ -56,6 +56,11 @@ public class StreamingRows : Rows
 
     protected override ResultSetStats? Stats => IsPositionedAtInMemResultSetWithAllData ? CurrentInMemResultSet.Stats : _stats;
 
+    public override Task<ResultSetStats?> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Stats);
+    }
+
     public override ResultSetMetadata? Metadata => IsPositionedAtInMemResultSet ? CurrentInMemResultSet.Metadata : _metadata;
 
     internal static StreamingRows Create(GrpcLibSpanner spanner, Connection connection, AsyncServerStreamingCall<RowData> stream)


### PR DESCRIPTION
Introduced asynchronous StatsAsync methods in ISpannerLib and GrpcLibSpanner, along with async GetStatsAsync and GetUpdateCountAsync helpers in Rows.cs.

This enables GetTotalUpdateCountAsync to run completely asynchronously. In StreamingRows, GetStatsAsync returns the local cached stats in memory, ensuring no remote blocking IPC calls are executed during asynchronous DML execution.
