### PR TITLE
test: add a test for JSON materialization

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -2874,13 +2874,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
                 ]
             ));
 
-            using (var db = new MockServerSampleDbContext(ConnectionString))
-            {
-                var result = await db.TicketSales.FirstOrDefaultAsync(t => t.Id == 1);
-                Assert.NotNull(result);
-                Assert.Equal("123", result.Receipt.Number);
-                Assert.Equal(new DateOnly(2026, 6, 29), result.Receipt.Date);
-            }
+            await using var db = new MockServerSampleDbContext(ConnectionString);
+            var result = await db.TicketSales.FirstOrDefaultAsync(t => t.Id == 1);
+            Assert.NotNull(result);
+            Assert.Equal("123", result.Receipt.Number);
+            Assert.Equal(new DateOnly(2026, 6, 29), result.Receipt.Date);
         }
 
         private string AddFindSingerResult(string sql)

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -2856,6 +2856,33 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             });
         }
 
+        [Fact]
+        public async Task JsonQuery_Materializes_Correctly()
+        {
+            var sql = "SELECT `t`.`Id`, `t`.`CustomerName`, `t`.`Receipt`" + Environment.NewLine +
+                "FROM `TicketSales` AS `t`" + Environment.NewLine +
+                "WHERE `t`.`Id` = 1" + Environment.NewLine +
+                "LIMIT 1";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
+                [
+                    Tuple.Create(V1.TypeCode.Int64, "Id"),
+                    Tuple.Create(V1.TypeCode.String, "CustomerName"),
+                    Tuple.Create(V1.TypeCode.Json, "Receipt"),
+                ],
+                [
+                    [1L, "Customer Name", "{\"Number\":\"123\",\"Date\":\"2026-06-29\"}"]
+                ]
+            ));
+
+            using (var db = new MockServerSampleDbContext(ConnectionString))
+            {
+                var result = await db.TicketSales.FirstOrDefaultAsync(t => t.Id == 1);
+                Assert.NotNull(result);
+                Assert.Equal("123", result.Receipt.Number);
+                Assert.Equal(new DateOnly(2026, 6, 29), result.Receipt.Date);
+            }
+        }
+
         private string AddFindSingerResult(string sql)
         {
             _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerStructuralJsonTypeMapping.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerStructuralJsonTypeMapping.cs
@@ -53,9 +53,20 @@ public class SpannerStructuralJsonTypeMapping : JsonTypeMapping
     public override MethodInfo GetDataReaderMethod() => GetStringMethod;
 
     public static MemoryStream CreateUtf8Stream(string json)
-        => json == ""
-            ? throw new InvalidOperationException("json cannot be an empty string.")
-            : new MemoryStream(Encoding.UTF8.GetBytes(json));
+    {
+        if (json == "")
+        {
+            throw new InvalidOperationException("json cannot be an empty string.");
+        }
+
+        // Note: The stream returned here is compiled into the EF Core query shaper delegate
+        // and passed to the JSON deserializer. EF Core does NOT dispose of this stream after
+        // materialization.
+        // Therefore, we cannot use ArrayPool or other pooled resources here, as they would
+        // leak. Allocating a new byte array and MemoryStream and letting the Garbage Collector
+        // clean them up is the safest and most efficient approach for this lifecycle.
+        return new MemoryStream(Encoding.UTF8.GetBytes(json));
+    }
 
     public override Expression CustomizeDataReaderExpression(Expression expression)
         => Expression.Call(CreateUtf8StreamMethod, expression);


### PR DESCRIPTION
During an attempt at optimizing the way that JSON queries are materialized, we discovered that Entity Framework does not dispose the stream that it receives. This means that we cannot easily optimize this by using for example a pooled buffer.
