### PR TITLE
chore(efcore): implement sync versions of Retry methods

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/RetriableStatementsTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/RetriableStatementsTests.cs
@@ -107,16 +107,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             var command = connection.SpannerConnection.CreateDmlCommand(sql);
             command.Transaction = transaction.SpannerTransaction;
             
-            SpannerException caughtException = null;
-            try
-            {
-                command.ExecuteNonQuery();
-            }
-            catch (SpannerException e)
-            {
-                caughtException = e;
-            }
-            Assert.NotNull(caughtException);
+            var caughtException = Assert.Throws<SpannerException>(() => command.ExecuteNonQuery());
             
             var statement = new FailedDmlStatement(command, caughtException);
             
@@ -139,16 +130,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             var command = connection.SpannerConnection.CreateDmlCommand(sql);
             command.Transaction = transaction.SpannerTransaction;
             
-            SpannerException caughtException = null;
-            try
-            {
-                command.ExecuteNonQuery();
-            }
-            catch (SpannerException e)
-            {
-                caughtException = e;
-            }
-            Assert.NotNull(caughtException);
+            var caughtException = Assert.Throws<SpannerException>(() => command.ExecuteNonQuery());
             
             var statement = new FailedDmlStatement(command, caughtException);
             
@@ -205,17 +187,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             batchCmd.Add(sql1);
             batchCmd.Add(sql2);
             
-            SpannerException caughtException = null;
-            try
-            {
-                batchCmd.ExecuteNonQuery();
-            }
-            catch (SpannerException e)
-            {
-                caughtException = e;
-            }
-            Assert.NotNull(caughtException);
-            Assert.IsType<SpannerBatchNonQueryException>(caughtException);
+            var caughtException = Assert.Throws<SpannerBatchNonQueryException>(() => batchCmd.ExecuteNonQuery());
             
             var statement = new FailedBatchDmlStatement(batchCmd, caughtException);
             

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/RetriableStatementsTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/RetriableStatementsTests.cs
@@ -1,0 +1,226 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.EntityFrameworkCore.Spanner.Storage;
+using Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal;
+using Google.Cloud.Spanner.Data;
+using V1 = Google.Cloud.Spanner.V1;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
+{
+#pragma warning disable EF1001 // Internal EF Core API usage.
+    public class RetriableStatementsTests : IClassFixture<SpannerMockServerFixture>
+    {
+        private readonly SpannerMockServerFixture _fixture;
+        private readonly SessionPoolManager _manager;
+
+        public RetriableStatementsTests(SpannerMockServerFixture service)
+        {
+            _fixture = service;
+            _fixture.SpannerMock.Reset();
+            
+            var options = new V1.SessionPoolOptions();
+            options.MinimumPooledSessions = 4;
+            options.MaximumActiveSessions = 8;
+            options.WaitOnResourcesExhausted = V1.ResourcesExhaustedBehavior.Fail;
+            _manager = SessionPoolManager.Create(options);
+        }
+
+        private SpannerRetriableConnection CreateConnection()
+        {
+            var connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            var builder = new SpannerConnectionStringBuilder(connectionString, ChannelCredentials.Insecure);
+            builder.SessionPoolManager = _manager;
+            return new SpannerRetriableConnection(new SpannerConnection(builder));
+        }
+
+        [Fact]
+        public void RetriableDmlStatement_SyncRetry_Succeeds()
+        {
+            string sql = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var command = connection.SpannerConnection.CreateDmlCommand(sql);
+            command.Transaction = transaction.SpannerTransaction;
+            
+            var updateCount = command.ExecuteNonQuery();
+            var statement = new RetriableDmlStatement(command, updateCount);
+            
+            using var retryTransaction = connection.BeginTransaction();
+            ((IRetriableStatement)statement).Retry(retryTransaction, 60);
+        }
+
+        [Fact]
+        public void RetriableDmlStatement_SyncRetry_FailsOnModifiedCount()
+        {
+            string sql = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var command = connection.SpannerConnection.CreateDmlCommand(sql);
+            command.Transaction = transaction.SpannerTransaction;
+            
+            var updateCount = command.ExecuteNonQuery();
+            var statement = new RetriableDmlStatement(command, updateCount);
+            
+            // Change DB response for the retry attempt
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(2));
+            
+            using var retryTransaction = connection.BeginTransaction();
+            Assert.Throws<SpannerAbortedDueToConcurrentModificationException>(() =>
+                ((IRetriableStatement)statement).Retry(retryTransaction, 60));
+        }
+
+        [Fact]
+        public void FailedDmlStatement_SyncRetry_Succeeds()
+        {
+            string sql = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(
+                new RpcException(new Status(StatusCode.InvalidArgument, "Invalid statement"))));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var command = connection.SpannerConnection.CreateDmlCommand(sql);
+            command.Transaction = transaction.SpannerTransaction;
+            
+            SpannerException caughtException = null;
+            try
+            {
+                command.ExecuteNonQuery();
+            }
+            catch (SpannerException e)
+            {
+                caughtException = e;
+            }
+            Assert.NotNull(caughtException);
+            
+            var statement = new FailedDmlStatement(command, caughtException);
+            
+            using var retryTransaction = connection.BeginTransaction();
+            // During retry, the same exception is thrown, which the statement translates into a success/return
+            ((IRetriableStatement)statement).Retry(retryTransaction, 60);
+        }
+
+        [Fact]
+        public void FailedDmlStatement_SyncRetry_FailsOnDifferentError()
+        {
+            string sql = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(
+                new RpcException(new Status(StatusCode.InvalidArgument, "Invalid statement"))));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var command = connection.SpannerConnection.CreateDmlCommand(sql);
+            command.Transaction = transaction.SpannerTransaction;
+            
+            SpannerException caughtException = null;
+            try
+            {
+                command.ExecuteNonQuery();
+            }
+            catch (SpannerException e)
+            {
+                caughtException = e;
+            }
+            Assert.NotNull(caughtException);
+            
+            var statement = new FailedDmlStatement(command, caughtException);
+            
+            // Change DB response to a different error for the retry
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(
+                new RpcException(new Status(StatusCode.Internal, "Internal error"))));
+            
+            using var retryTransaction = connection.BeginTransaction();
+            Assert.Throws<SpannerAbortedDueToConcurrentModificationException>(() =>
+                ((IRetriableStatement)statement).Retry(retryTransaction, 60));
+        }
+
+        [Fact]
+        public void RetriableBatchDmlStatement_SyncRetry_Succeeds()
+        {
+            string sql1 = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            string sql2 = $"UPDATE Foo SET Bar='baz' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateUpdateCount(2));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var batchCmd = connection.CreateBatchDmlCommand();
+            batchCmd.Transaction = transaction;
+            batchCmd.Add(sql1);
+            batchCmd.Add(sql2);
+            
+            var updateCounts = batchCmd.ExecuteNonQuery();
+            Assert.Equal(new List<long> { 1, 2 }, updateCounts);
+            
+            var statement = new RetriableBatchDmlStatement(batchCmd, updateCounts);
+            
+            using var retryTransaction = connection.BeginTransaction();
+            ((IRetriableStatement)statement).Retry(retryTransaction, 60);
+        }
+
+        [Fact]
+        public void FailedBatchDmlStatement_SyncRetry_Succeeds()
+        {
+            string sql1 = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            string sql2 = $"UPDATE Foo SET Bar='baz' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateException(
+                new RpcException(new Status(StatusCode.InvalidArgument, "Invalid statement"))));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var batchCmd = connection.CreateBatchDmlCommand();
+            batchCmd.Transaction = transaction;
+            batchCmd.Add(sql1);
+            batchCmd.Add(sql2);
+            
+            SpannerException caughtException = null;
+            try
+            {
+                batchCmd.ExecuteNonQuery();
+            }
+            catch (SpannerException e)
+            {
+                caughtException = e;
+            }
+            Assert.NotNull(caughtException);
+            Assert.IsType<SpannerBatchNonQueryException>(caughtException);
+            
+            var statement = new FailedBatchDmlStatement(batchCmd, caughtException);
+            
+            using var retryTransaction = connection.BeginTransaction();
+            ((IRetriableStatement)statement).Retry(retryTransaction, 60);
+        }
+    }
+}

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
@@ -73,7 +73,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             try
             {
                 _command.Transaction = transaction;
-                _command.CreateSpannerBatchCommand().ExecuteNonQuery();
+                var batchCommand = _command.CreateSpannerBatchCommand();
+                batchCommand.CommandTimeout = timeoutSeconds;
+                batchCommand.ExecuteNonQuery();
                 // Fallthrough and throw the exception at the end of the method.
             }
             catch (SpannerBatchNonQueryException e)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
@@ -67,5 +67,38 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             }
             throw new SpannerAbortedDueToConcurrentModificationException();
         }
+
+        void IRetriableStatement.Retry(SpannerRetriableTransaction transaction, int timeoutSeconds)
+        {
+            try
+            {
+                _command.CreateSpannerBatchCommand().ExecuteNonQuery();
+                // Fallthrough and throw the exception at the end of the method.
+            }
+            catch (SpannerBatchNonQueryException e)
+            {
+                // Check that we got the exact same exception and results this time as the previous time.
+                if (_exception is SpannerBatchNonQueryException batchException
+                    && e.ErrorCode == _exception.ErrorCode
+                    && e.Message.Equals(_exception.Message)
+                    // A Batch DML statement returns the update counts of the first N statements and the error
+                    // that occurred for statement N+1.
+                    && e.SuccessfulCommandResults.SequenceEqual(batchException.SuccessfulCommandResults)
+                    )
+                {
+                    return;
+                }
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                // Check that we got the exact same exception during the retry as during the initial attempt.
+                // This happens if the Batch DML RPC itself failed, and not one of the DML statements.
+                if (!(_exception is SpannerBatchNonQueryException) && SpannerRetriableTransaction.SpannerExceptionsEqualForRetry(e, _exception))
+                {
+                    return;
+                }
+            }
+            throw new SpannerAbortedDueToConcurrentModificationException();
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
@@ -72,6 +72,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         {
             try
             {
+                _command.Transaction = transaction;
                 _command.CreateSpannerBatchCommand().ExecuteNonQuery();
                 // Fallthrough and throw the exception at the end of the method.
             }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedDmlStatement.cs
@@ -57,6 +57,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             try
             {
                 _command.Transaction = transaction.SpannerTransaction;
+                _command.CommandTimeout = timeoutSeconds;
                 _command.ExecuteNonQuery();
                 // Fallthrough and throw the exception at the end of the method.
             }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedDmlStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021, Google Inc. All rights reserved.
+// Copyright 2021, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,25 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             {
                 _command.Transaction = transaction.SpannerTransaction;
                 await _command.ExecuteNonQueryAsync(cancellationToken);
+                // Fallthrough and throw the exception at the end of the method.
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                // Check that we got the exact same exception this time as the previous time.
+                if (SpannerRetriableTransaction.SpannerExceptionsEqualForRetry(e, _exception))
+                {
+                    return;
+                }
+            }
+            throw new SpannerAbortedDueToConcurrentModificationException();
+        }
+
+        void IRetriableStatement.Retry(SpannerRetriableTransaction transaction, int timeoutSeconds)
+        {
+            try
+            {
+                _command.Transaction = transaction.SpannerTransaction;
+                _command.ExecuteNonQuery();
                 // Fallthrough and throw the exception at the end of the method.
             }
             catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/IRetriableStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/IRetriableStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021, Google Inc. All rights reserved.
+// Copyright 2021, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,5 +23,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
     internal interface IRetriableStatement
     {
         internal Task RetryAsync(SpannerRetriableTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds);
+
+        internal void Retry(SpannerRetriableTransaction transaction, int timeoutSeconds);
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableBatchDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableBatchDmlStatement.cs
@@ -57,7 +57,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             try
             {
                 _command.Transaction = transaction;
-                if (!_updateCounts.SequenceEqual(_command.CreateSpannerBatchCommand().ExecuteNonQuery()))
+                var batchCommand = _command.CreateSpannerBatchCommand();
+                batchCommand.CommandTimeout = timeoutSeconds;
+                if (!_updateCounts.SequenceEqual(batchCommand.ExecuteNonQuery()))
                 {
                     throw new SpannerAbortedDueToConcurrentModificationException();
                 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableBatchDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableBatchDmlStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021, Google Inc. All rights reserved.
+// Copyright 2021, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,22 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             {
                 _command.Transaction = transaction;
                 if (!_updateCounts.SequenceEqual(await _command.CreateSpannerBatchCommand().ExecuteNonQueryAsync(cancellationToken)))
+                {
+                    throw new SpannerAbortedDueToConcurrentModificationException();
+                }
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                throw new SpannerAbortedDueToConcurrentModificationException();
+            }
+        }
+
+        void IRetriableStatement.Retry(SpannerRetriableTransaction transaction, int timeoutSeconds)
+        {
+            try
+            {
+                _command.Transaction = transaction;
+                if (!_updateCounts.SequenceEqual(_command.CreateSpannerBatchCommand().ExecuteNonQuery()))
                 {
                     throw new SpannerAbortedDueToConcurrentModificationException();
                 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableDmlStatement.cs
@@ -55,6 +55,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             try
             {
                 _command.Transaction = transaction.SpannerTransaction;
+                _command.CommandTimeout = timeoutSeconds;
                 // The DML statement should return the same update count as during the initial attempt
                 // for the retry to be deemed successful.
                 if (_command.ExecuteNonQuery() != _updateCount)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableDmlStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021, Google Inc. All rights reserved.
+// Copyright 2021, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,24 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 // The DML statement should return the same update count as during the initial attempt
                 // for the retry to be deemed successful.
                 if (await _command.ExecuteNonQueryAsync(cancellationToken) != _updateCount)
+                {
+                    throw new SpannerAbortedDueToConcurrentModificationException();
+                }
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                throw new SpannerAbortedDueToConcurrentModificationException();
+            }
+        }
+
+        void IRetriableStatement.Retry(SpannerRetriableTransaction transaction, int timeoutSeconds)
+        {
+            try
+            {
+                _command.Transaction = transaction.SpannerTransaction;
+                // The DML statement should return the same update count as during the initial attempt
+                // for the retry to be deemed successful.
+                if (_command.ExecuteNonQuery() != _updateCount)
                 {
                     throw new SpannerAbortedDueToConcurrentModificationException();
                 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
@@ -176,6 +176,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             }
         }
 
+        void IRetriableStatement.Retry(SpannerRetriableTransaction transaction, int timeoutSeconds)
+        {
+            throw new System.NotImplementedException();
+        }
+
         async Task IRetriableStatement.RetryAsync(SpannerRetriableTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)
         {
             _spannerCommand.Transaction = transaction.SpannerTransaction;


### PR DESCRIPTION
This is the first step in a multi-step change to natively support synchronous versions of the Retry methods for aborted transactions. This step adds support for a sync version of the Retry method for DML and Batch DML statements.
