### PR TITLE
chore: use native sync methods for sync retry

### DIFF
--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/AbortedTransactionsTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/AbortedTransactionsTests.cs
@@ -1187,6 +1187,156 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
                 Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
             }
         }
+
+        [Fact]
+        public void ReadWriteTransaction_Sync_ModifiedDmlUpdateCount_FailsRetry()
+        {
+            string sql = $"UPDATE Foo SET Bar='baz' WHERE Id IN ({_fixture.RandomLong()},{_fixture.RandomLong()})";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            var cmd = connection.CreateDmlCommand(sql);
+            cmd.Transaction = transaction;
+            Assert.Equal(1, cmd.ExecuteNonQuery());
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(2));
+
+            _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+            cmd = connection.CreateDmlCommand($"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}");
+            cmd.Transaction = transaction;
+            Assert.Throws<SpannerAbortedDueToConcurrentModificationException>(() => cmd.ExecuteNonQuery());
+            Assert.Equal(1, transaction.RetryCount);
+        }
+
+        [Fact]
+        public void ReadWriteTransaction_Sync_DmlThenReturn_DataChanged_FailsRetry()
+        {
+            string sql = $"UPDATE Foo SET Bar='baz' WHERE Id IN ({_fixture.RandomLong()},{_fixture.RandomLong()}) THEN RETURN Baz";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(1, new V1.Type{Code = V1.TypeCode.String}, "Baz", "Test1"));
+
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            var cmd = connection.CreateDmlCommand(sql);
+            cmd.Transaction = transaction;
+            using (var reader = cmd.ExecuteReader())
+            {
+                var count = 0;
+                while (reader.Read())
+                {
+                    Assert.Equal("Test1", reader.GetString(0));
+                    count++;
+                }
+                Assert.Equal(1, count);
+            }
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(1, new V1.Type{Code = V1.TypeCode.String}, "Baz", "Test2"));
+
+            _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+            cmd = connection.CreateDmlCommand($"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}");
+            cmd.Transaction = transaction;
+            Assert.Throws<SpannerAbortedDueToConcurrentModificationException>(() => cmd.ExecuteNonQuery());
+            Assert.Equal(1, transaction.RetryCount);
+        }
+
+        [Fact]
+        public void ReadWriteTransaction_Sync_Retry_GivesUp()
+        {
+            string sql = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            transaction.EnableInternalRetries = true;
+            transaction.MaxInternalRetryCount = 3;
+            var cmd = connection.CreateDmlCommand(sql);
+            cmd.Transaction = transaction;
+            Assert.Equal(1, cmd.ExecuteNonQuery());
+            
+            for (var i = 0; i < 3; i++)
+            {
+                _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+                var cmd2 = connection.CreateDmlCommand(sql);
+                cmd2.Transaction = transaction;
+                var updateCount = cmd2.ExecuteNonQuery();
+                Assert.Equal(1, updateCount);
+                Assert.Equal(i + 1, transaction.RetryCount);
+            }
+            _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+            var cmd3 = connection.CreateDmlCommand(sql);
+            cmd3.Transaction = transaction;
+            var e = Assert.Throws<SpannerException>(() => cmd3.ExecuteNonQuery());
+            Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
+            Assert.Contains("Transaction was aborted because it aborted and retried too many times", e.Message);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadWriteTransaction_Sync_ReadScalar_CanBeRetried(bool enableInternalRetries)
+        {
+            string sql = $"SELECT Id FROM Foo WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.Int64 }, "Id", 1));
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            transaction.EnableInternalRetries = enableInternalRetries;
+            var cmd = connection.CreateSelectCommand(sql);
+            cmd.Transaction = transaction;
+            var id = cmd.ExecuteScalar();
+            Assert.Equal(1L, id);
+            // Abort the transaction on the mock server. The transaction should be able to internally retry.
+            _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+            if (enableInternalRetries)
+            {
+                transaction.Commit();
+                Assert.Equal(1, transaction.RetryCount);
+            }
+            else
+            {
+                var e = Assert.Throws<SpannerException>(() => transaction.Commit());
+                Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadWriteTransaction_Sync_QueryAbortsHalfway_WithSameResults_CanBeRetried(bool enableInternalRetries)
+        {
+            string sql = $"SELECT Id FROM Foo WHERE Id IN ({_fixture.RandomLong()}, {_fixture.RandomLong()})";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.Int64 }, "Id", 1, 2));
+            var streamWritePermissions = new BlockingCollection<int>
+            {
+                1
+            };
+            var executionTime = ExecutionTime.StreamException(MockSpannerService.CreateAbortedException(sql), 1, streamWritePermissions);
+            _fixture.SpannerMock.AddOrUpdateExecutionTime(nameof(MockSpannerService.ExecuteStreamingSql), executionTime);
+
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            transaction.EnableInternalRetries = enableInternalRetries;
+            var cmd = connection.CreateSelectCommand(sql);
+            cmd.Transaction = transaction;
+            using var reader = cmd.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+
+            executionTime.AlwaysAllowWrite();
+            if (enableInternalRetries)
+            {
+                Assert.True(reader.Read());
+                Assert.Equal(2, reader.GetInt64(reader.GetOrdinal("Id")));
+                Assert.False(reader.Read());
+                Assert.Equal(1, transaction.RetryCount);
+            }
+            else
+            {
+                var e = Assert.Throws<SpannerException>(() => reader.Read());
+                Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
+            }
+        }
     }
 #pragma warning restore EF1001 // Internal EF Core API usage.
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/AbortedTransactionsTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/AbortedTransactionsTests.cs
@@ -1061,6 +1061,132 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
             Assert.Contains("Transaction was aborted because it aborted and retried too many times", e.Message);
         }
+
+        [Fact]
+        public void ReadWriteTransaction_Sync_WithoutAbort_DoesNotRetry()
+        {
+            string sql = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+
+            var cmd = connection.CreateDmlCommand(sql);
+            cmd.Transaction = transaction;
+            var updateCount = cmd.ExecuteNonQuery();
+            var commitTimestamp = transaction.CommitAndReturnCommitTimestamp();
+            Assert.NotEqual(DateTime.UnixEpoch, commitTimestamp);
+            Assert.Equal(1, updateCount);
+            Assert.Equal(0, transaction.RetryCount);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadWriteTransaction_Sync_AbortedDml_IsAutomaticallyRetried(bool enableInternalRetries)
+        {
+            _fixture.SpannerMock.AddOrUpdateStatementResult("SELECT 1", StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.Int64 }, "c", 1));
+            string sql = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            transaction.EnableInternalRetries = enableInternalRetries;
+            // Execute a statement to ensure the transaction has been initialized.
+            var selectCmd = connection.CreateSelectCommand("SELECT 1");
+            selectCmd.Transaction = transaction;
+            selectCmd.ExecuteScalar();
+            
+            // Abort the transaction on the mock server. The transaction should be able to internally retry.
+            _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+            var cmd = connection.CreateDmlCommand(sql);
+            cmd.Transaction = transaction;
+            if (enableInternalRetries)
+            {
+                var updateCount = cmd.ExecuteNonQuery();
+                Assert.Equal(1, updateCount);
+                Assert.Equal(1, transaction.RetryCount);
+            }
+            else
+            {
+                var e = Assert.Throws<SpannerException>(() => cmd.ExecuteNonQuery());
+                Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadWriteTransaction_Sync_QueryFullyConsumed_CanBeRetried(bool enableInternalRetries)
+        {
+            string sql = $"SELECT Id FROM Foo WHERE Id={_fixture.RandomLong()}";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.Int64 }, "Id", 1));
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            transaction.EnableInternalRetries = enableInternalRetries;
+            var cmd = connection.CreateSelectCommand(sql);
+            cmd.Transaction = transaction;
+            using (var reader = cmd.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+                }
+            }
+            // Abort the transaction on the mock server. The transaction should be able to internally retry.
+            _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+            if (enableInternalRetries)
+            {
+                transaction.Commit();
+                Assert.Equal(1, transaction.RetryCount);
+            }
+            else
+            {
+                var e = Assert.Throws<SpannerException>(() => transaction.Commit());
+                Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadWriteTransaction_Sync_AbortedBatchDml_IsAutomaticallyRetried(bool enableInternalRetries)
+        {
+            _fixture.SpannerMock.AddOrUpdateStatementResult("SELECT 1", StatementResult.CreateSingleColumnResultSet(new V1.Type { Code = V1.TypeCode.Int64 }, "c", 1));
+            string sql1 = $"UPDATE Foo SET Bar='bar' WHERE Id={_fixture.RandomLong()}";
+            string sql2 = $"UPDATE Foo SET Bar='baz' WHERE Id IN ({_fixture.RandomLong()},{_fixture.RandomLong()})";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateUpdateCount(2));
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            transaction.EnableInternalRetries = enableInternalRetries;
+            // Execute a statement to ensure the transaction has been initialized.
+            var selectCmd = connection.CreateSelectCommand("SELECT 1");
+            selectCmd.Transaction = transaction;
+            selectCmd.ExecuteScalar();
+            
+            var cmd = connection.CreateBatchDmlCommand();
+            cmd.Transaction = transaction;
+            cmd.Add(sql1);
+            cmd.Add(sql2);
+
+            // Abort the transaction on the mock server. The transaction should be able to internally retry.
+            _fixture.SpannerMock.AbortTransaction(transaction.TransactionId);
+
+            if (enableInternalRetries)
+            {
+                var updateCounts = cmd.ExecuteNonQuery();
+                Assert.Equal(new List<long> { 1, 2 }, updateCounts);
+                Assert.Equal(1, transaction.RetryCount);
+            }
+            else
+            {
+                var e = Assert.Throws<SpannerException>(() => cmd.ExecuteNonQuery());
+                Assert.Equal(ErrorCode.Aborted, e.ErrorCode);
+            }
+        }
     }
 #pragma warning restore EF1001 // Internal EF Core API usage.
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/EntityFrameworkMockServerTests.cs
@@ -2401,6 +2401,31 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
         }
 
         [Fact]
+        public void CanInsertCommitTimestamp_Sync()
+        {
+            using var db = new MockServerSampleDbContext(ConnectionString);
+            var sql = "INSERT INTO `TableWithAllColumnTypes` (`ColCommitTS`, `ColInt64`, `ASC`, `ColBool`, " +
+                "`ColBoolArray`, `ColBytes`, `ColBytesArray`, `ColBytesMax`, `ColBytesMaxArray`, `ColDate`, `ColDateArray`," +
+                " `ColFloat32`, `ColFloat32Array`, `ColFloat64`, `ColFloat64Array`, `ColInt64Array`, `ColJson`, `ColJsonArray`, `ColNumeric`, `ColNumericArray`, `ColString`, " +
+                "`ColStringArray`, `ColStringMax`, `ColStringMaxArray`, `ColTimestamp`, `ColTimestampArray`)" +
+                $"{Environment.NewLine}VALUES (PENDING_COMMIT_TIMESTAMP(), " +
+                $"@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19, @p20, @p21, @p22, @p23, @p24){Environment.NewLine}" +
+                $"THEN RETURN `ColComputed`";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(1L, new V1.Type { Code = V1.TypeCode.String }, "ColComputed", "Test"));
+
+            db.TableWithAllColumnTypes.Add(new TableWithAllColumnTypes { ColInt64 = 1L });
+            db.SaveChanges();
+
+            Assert.Collection(
+                _fixture.SpannerMock.Requests.OfType<ExecuteSqlRequest>(),
+                request =>
+                {
+                    Assert.Contains("PENDING_COMMIT_TIMESTAMP()", request.Sql);
+                }
+            );
+        }
+
+        [Fact]
         public async Task CanUpdateCommitTimestamp()
         {
             using var db = new MockServerSampleDbContext(ConnectionString);
@@ -2413,6 +2438,29 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             db.TableWithAllColumnTypes.Attach(row);
             row.ColBool = true;
             await db.SaveChangesAsync();
+
+            Assert.Collection(
+                _fixture.SpannerMock.Requests.OfType<ExecuteSqlRequest>(),
+                request =>
+                {
+                    Assert.Contains("PENDING_COMMIT_TIMESTAMP()", request.Sql);
+                }
+            );
+        }
+
+        [Fact]
+        public void CanUpdateCommitTimestamp_Sync()
+        {
+            using var db = new MockServerSampleDbContext(ConnectionString);
+            var sql = $"UPDATE `TableWithAllColumnTypes` SET `ColCommitTS` = PENDING_COMMIT_TIMESTAMP(), `ColBool` = @p0" +
+                $"{Environment.NewLine}WHERE `ColInt64` = @p1{Environment.NewLine}" +
+                $"THEN RETURN `ColComputed`";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(1L, new V1.Type { Code = V1.TypeCode.String }, "ColComputed", "Test"));
+
+            var row = new TableWithAllColumnTypes { ColInt64 = 1L };
+            db.TableWithAllColumnTypes.Attach(row);
+            row.ColBool = true;
+            db.SaveChanges();
 
             Assert.Collection(
                 _fixture.SpannerMock.Requests.OfType<ExecuteSqlRequest>(),

--- a/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/RetriableStatementsTests.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner.Tests/Storage/RetriableStatementsTests.cs
@@ -194,5 +194,80 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Tests
             using var retryTransaction = connection.BeginTransaction();
             ((IRetriableStatement)statement).Retry(retryTransaction, 60);
         }
+
+        [Fact]
+        public void SpannerDataReaderWithChecksum_SyncRetry_Succeeds()
+        {
+            string sql = "SELECT * FROM Foo WHERE Id = 1";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
+                [
+                    Tuple.Create(V1.TypeCode.Int64, "Id"),
+                    Tuple.Create(V1.TypeCode.String, "Name"),
+                ],
+                [
+                    [1L, "Test Name"]
+                ]
+            ));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var command = connection.SpannerConnection.CreateSelectCommand(sql);
+            command.Transaction = transaction.SpannerTransaction;
+            
+            using var reader = command.ExecuteReader();
+            var checksumReader = new SpannerDataReaderWithChecksum(transaction, (SpannerDataReader)reader, command);
+            
+            Assert.True(checksumReader.Read());
+            Assert.Equal(1L, checksumReader.GetInt64(0));
+            Assert.Equal("Test Name", checksumReader.GetString(1));
+            Assert.False(checksumReader.Read());
+            
+            using var retryTransaction = connection.BeginTransaction();
+            ((IRetriableStatement)checksumReader).Retry(retryTransaction, 60);
+        }
+
+        [Fact]
+        public void SpannerDataReaderWithChecksum_SyncRetry_FailsOnModifiedResults()
+        {
+            string sql = "SELECT * FROM Foo WHERE Id = 1";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
+                [
+                    Tuple.Create(V1.TypeCode.Int64, "Id"),
+                    Tuple.Create(V1.TypeCode.String, "Name"),
+                ],
+                [
+                    [1L, "Test Name"]
+                ]
+            ));
+            
+            using var connection = CreateConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            
+            var command = connection.SpannerConnection.CreateSelectCommand(sql);
+            command.Transaction = transaction.SpannerTransaction;
+            
+            using var reader = command.ExecuteReader();
+            var checksumReader = new SpannerDataReaderWithChecksum(transaction, (SpannerDataReader)reader, command);
+            
+            Assert.True(checksumReader.Read());
+            Assert.False(checksumReader.Read());
+            
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateResultSet(
+                [
+                    Tuple.Create(V1.TypeCode.Int64, "Id"),
+                    Tuple.Create(V1.TypeCode.String, "Name"),
+                ],
+                [
+                    [1L, "Modified Name"]
+                ]
+            ));
+            
+            using var retryTransaction = connection.BeginTransaction();
+            Assert.Throws<SpannerAbortedDueToConcurrentModificationException>(() =>
+                ((IRetriableStatement)checksumReader).Retry(retryTransaction, 60));
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedBatchDmlStatement.cs
@@ -103,5 +103,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             }
             throw new SpannerAbortedDueToConcurrentModificationException();
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/FailedDmlStatement.cs
@@ -71,5 +71,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             }
             throw new SpannerAbortedDueToConcurrentModificationException();
         }
+
+        public void Dispose()
+        {
+            _command.Dispose();
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/IRetriableStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/IRetriableStatement.cs
@@ -20,10 +20,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
     /// <summary>
     /// Base interface for all statements that can be retried by SpannerRetriableTransaction.
     /// </summary>
-    internal interface IRetriableStatement
+    internal interface IRetriableStatement : System.IDisposable
     {
         internal Task RetryAsync(SpannerRetriableTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds);
-
+ 
         internal void Retry(SpannerRetriableTransaction transaction, int timeoutSeconds);
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableBatchDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableBatchDmlStatement.cs
@@ -69,5 +69,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 throw new SpannerAbortedDueToConcurrentModificationException();
             }
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableDmlStatement.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/RetriableDmlStatement.cs
@@ -68,5 +68,10 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 throw new SpannerAbortedDueToConcurrentModificationException();
             }
         }
+
+        public void Dispose()
+        {
+            _command.Dispose();
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
@@ -178,7 +178,54 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         void IRetriableStatement.Retry(SpannerRetriableTransaction transaction, int timeoutSeconds)
         {
-            throw new System.NotImplementedException();
+            _spannerCommand.Transaction = transaction.SpannerTransaction;
+            var reader = (SpannerDataReader)_spannerCommand.ExecuteReader();
+            int counter = 0;
+            bool read = true;
+            using var retryHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            SpannerException newException = null;
+            while (read && counter < _numberOfReadCalls)
+            {
+                try
+                {
+                    read = reader.Read();
+                    AppendRowToHash(retryHash, reader, read);
+                    counter++;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    // Propagate Aborted errors to trigger a new retry.
+                    throw;
+                }
+                catch (SpannerException e)
+                {
+                    newException = e;
+                    counter++;
+                    break;
+                }
+            }
+            var originalChecksum = GetChecksum();
+            var newChecksum = retryHash.GetHashAndReset();
+            if (counter == _numberOfReadCalls
+                && newChecksum.SequenceEqual(originalChecksum)
+                && SpannerRetriableTransaction.SpannerExceptionsEqualForRetry(newException, _firstException))
+            {
+                // Checksum is ok, we only need to replace the delegate result set if it's still open.
+                if (IsClosed)
+                {
+                    reader.Close();
+                }
+                else
+                {
+                    _spannerDataReader = reader;
+                }
+            }
+            else
+            {
+                // The results are not equal, there is an actual concurrent modification, so we cannot
+                // continue the transaction.
+                throw new SpannerAbortedDueToConcurrentModificationException();
+            }
         }
 
         async Task IRetriableStatement.RetryAsync(SpannerRetriableTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerDataReaderWithChecksum.cs
@@ -91,6 +91,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             if (disposing)
             {
                 _spannerDataReader.Dispose();
+                _spannerCommand.Dispose();
                 if (!_hashDisposed)
                 {
                     // Cache the final checksum before disposing the IncrementalHash, as the transaction
@@ -105,15 +106,25 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         }
 
         /// <inheritdoc />
-        public override bool Read() => Task.Run(() => ReadAsync(CancellationToken.None)).ResultWithUnwrappedExceptions();
+        public override bool Read()
+        {
+            return ReadInternalAsync(async: false, CancellationToken.None).GetAwaiter().GetResult();
+        }
 
-        public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            return ReadInternalAsync(async: true, cancellationToken).AsTask();
+        }
+
+        private async ValueTask<bool> ReadInternalAsync(bool async, CancellationToken cancellationToken)
         {
             while (true)
             {
                 try
                 {
-                    bool res = await _spannerDataReader.ReadAsync(cancellationToken);
+                    bool res = async
+                        ? await _spannerDataReader.ReadAsync(cancellationToken)
+                        : _spannerDataReader.Read();
                     AppendRowToHash(_incrementalHash, _spannerDataReader, res);
                     _numberOfReadCalls++;
                     return res;
@@ -121,7 +132,14 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
                 {
                     // Retry the transaction and then retry the ReadAsync call.
-                    await Transaction.RetryAsync(e, cancellationToken);
+                    if (async)
+                    {
+                        await Transaction.RetryAsync(e, cancellationToken);
+                    }
+                    else
+                    {
+                        Transaction.Retry(e);
+                    }
                 }
                 catch (SpannerException e)
                 {
@@ -178,106 +196,81 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         void IRetriableStatement.Retry(SpannerRetriableTransaction transaction, int timeoutSeconds)
         {
-            _spannerCommand.Transaction = transaction.SpannerTransaction;
-            var reader = (SpannerDataReader)_spannerCommand.ExecuteReader();
-            int counter = 0;
-            bool read = true;
-            using var retryHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-            SpannerException newException = null;
-            while (read && counter < _numberOfReadCalls)
-            {
-                try
-                {
-                    read = reader.Read();
-                    AppendRowToHash(retryHash, reader, read);
-                    counter++;
-                }
-                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
-                {
-                    // Propagate Aborted errors to trigger a new retry.
-                    throw;
-                }
-                catch (SpannerException e)
-                {
-                    newException = e;
-                    counter++;
-                    break;
-                }
-            }
-            var originalChecksum = GetChecksum();
-            var newChecksum = retryHash.GetHashAndReset();
-            if (counter == _numberOfReadCalls
-                && newChecksum.SequenceEqual(originalChecksum)
-                && SpannerRetriableTransaction.SpannerExceptionsEqualForRetry(newException, _firstException))
-            {
-                // Checksum is ok, we only need to replace the delegate result set if it's still open.
-                if (IsClosed)
-                {
-                    reader.Close();
-                }
-                else
-                {
-                    _spannerDataReader = reader;
-                }
-            }
-            else
-            {
-                // The results are not equal, there is an actual concurrent modification, so we cannot
-                // continue the transaction.
-                throw new SpannerAbortedDueToConcurrentModificationException();
-            }
+            RetryInternalAsync(transaction, async: false, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         async Task IRetriableStatement.RetryAsync(SpannerRetriableTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)
         {
+            await RetryInternalAsync(transaction, async: true, cancellationToken);
+        }
+
+        private async ValueTask<bool> RetryInternalAsync(SpannerRetriableTransaction transaction, bool async, CancellationToken cancellationToken)
+        {
             _spannerCommand.Transaction = transaction.SpannerTransaction;
-            var reader = await _spannerCommand.ExecuteReaderAsync(cancellationToken);
-            int counter = 0;
-            bool read = true;
-            using var retryHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-            SpannerException newException = null;
-            while (read && counter < _numberOfReadCalls)
+            var reader = async
+                ? await _spannerCommand.ExecuteReaderAsync(cancellationToken)
+                : (SpannerDataReader)_spannerCommand.ExecuteReader();
+            bool keepReader = false;
+            try
             {
-                try
+                int counter = 0;
+                bool read = true;
+                using var retryHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+                SpannerException newException = null;
+                while (read && counter < _numberOfReadCalls)
                 {
-                    read = await reader.ReadAsync(cancellationToken);
-                    AppendRowToHash(retryHash, reader, read);
-                    counter++;
+                    try
+                    {
+                        read = async
+                            ? await reader.ReadAsync(cancellationToken)
+                            : reader.Read();
+                        AppendRowToHash(retryHash, reader, read);
+                        counter++;
+                    }
+                    catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                    {
+                        // Propagate Aborted errors to trigger a new retry.
+                        throw;
+                    }
+                    catch (SpannerException e)
+                    {
+                        newException = e;
+                        counter++;
+                        break;
+                    }
                 }
-                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                var originalChecksum = GetChecksum();
+                var newChecksum = retryHash.GetHashAndReset();
+                if (counter == _numberOfReadCalls
+                    && newChecksum.SequenceEqual(originalChecksum)
+                    && SpannerRetriableTransaction.SpannerExceptionsEqualForRetry(newException, _firstException))
                 {
-                    // Propagate Aborted errors to trigger a new retry.
-                    throw;
-                }
-                catch (SpannerException e)
-                {
-                    newException = e;
-                    counter++;
-                    break;
-                }
-            }
-            var originalChecksum = GetChecksum();
-            var newChecksum = retryHash.GetHashAndReset();
-            if (counter == _numberOfReadCalls
-                && newChecksum.SequenceEqual(originalChecksum)
-                && SpannerRetriableTransaction.SpannerExceptionsEqualForRetry(newException, _firstException))
-            {
-                // Checksum is ok, we only need to replace the delegate result set if it's still open.
-                if (IsClosed)
-                {
-                    reader.Close();
+                    // Checksum is ok, we only need to replace the delegate result set if it's still open.
+                    if (IsClosed)
+                    {
+                        reader.Close();
+                    }
+                    else
+                    {
+                        _spannerDataReader = reader;
+                        keepReader = true;
+                    }
                 }
                 else
                 {
-                    _spannerDataReader = reader;
+                    // The results are not equal, there is an actual concurrent modification, so we cannot
+                    // continue the transaction.
+                    throw new SpannerAbortedDueToConcurrentModificationException();
                 }
             }
-            else
+            finally
             {
-                // The results are not equal, there is an actual concurrent modification, so we cannot
-                // continue the transaction.
-                throw new SpannerAbortedDueToConcurrentModificationException();
+                if (!keepReader)
+                {
+                    reader.Dispose();
+                }
             }
+            return keepReader;
         }
 
         public override bool GetBoolean(int ordinal)

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableCommand.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableCommand.cs
@@ -136,5 +136,14 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         }
 
         public override void Prepare() => _spannerCommand.Prepare();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _spannerCommand.Dispose();
+            }
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
@@ -329,58 +329,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         internal void Retry(SpannerException abortedException, int timeoutSeconds = MAX_TIMEOUT_SECONDS)
         {
-            if (!EnableInternalRetries)
-            {
-                throw abortedException;
-            }
-            DateTime? overallDeadline = _options.CalculateDeadline(_clock);
-            TimeSpan retryDelay = _options.InitialDelay;
-            // If there's a recommended retry delay specified on the exception
-            // we should respect it.
-            retryDelay = abortedException.RecommendedRetryDelay ?? _options.Jitter(retryDelay);
-            while (true)
-            {
-                if (RetryCount >= MaxInternalRetryCount)
-                {
-                    throw new SpannerException(ErrorCode.Aborted, "Transaction was aborted because it aborted and retried too many times");
-                }
-
-                DateTime expectedRetryTime = _clock.GetCurrentDateTimeUtc() + retryDelay;
-                if (expectedRetryTime > overallDeadline)
-                {
-                    throw new SpannerException(ErrorCode.Aborted, "Transaction was aborted because it timed out while retrying");
-                }
-                _scheduler.Delay(retryDelay, CancellationToken.None).Wait();
-
-                // TODO: Preferably the Spanner client library should have some 'reset' option on an existing
-                // transaction instead of having to begin a new transaction. This will potentially use a transaction
-                // on a different session, while the recommended behavior for a retry is to use the same session as
-                // the original attempt.
-                SpannerTransaction.Dispose();
-                SpannerTransaction = Connection.SpannerConnection.BeginTransaction();
-                RetryCount++;
-                try
-                {
-                    foreach (IRetriableStatement statement in _retriableStatements)
-                    {
-                        statement.Retry(this, timeoutSeconds);
-                    }
-                    break;
-                }
-                catch (SpannerAbortedDueToConcurrentModificationException)
-                {
-                    // Retry failed because of a concurrent modification.
-                    throw;
-                }
-                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
-                {
-                    // Ignore and retry.
-                    retryDelay = e.RecommendedRetryDelay ?? _options.Jitter(_options.NextDelay(retryDelay));
-                }
-            }
+            RetryInternalAsync(abortedException, async: false, CancellationToken.None, timeoutSeconds).GetAwaiter().GetResult();
         }
 
         internal async Task RetryAsync(SpannerException abortedException, CancellationToken cancellationToken, int timeoutSeconds = MAX_TIMEOUT_SECONDS)
+        {
+            await RetryInternalAsync(abortedException, async: true, cancellationToken, timeoutSeconds);
+        }
+
+        private async ValueTask RetryInternalAsync(SpannerException abortedException, bool async, CancellationToken cancellationToken, int timeoutSeconds = MAX_TIMEOUT_SECONDS)
         {
             if (!EnableInternalRetries)
             {
@@ -403,20 +360,37 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 {
                     throw new SpannerException(ErrorCode.Aborted, "Transaction was aborted because it timed out while retrying");
                 }
-                await _scheduler.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+
+                if (async)
+                {
+                    await _scheduler.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    _scheduler.Delay(retryDelay, CancellationToken.None).Wait();
+                }
 
                 // TODO: Preferably the Spanner client library should have some 'reset' option on an existing
                 // transaction instead of having to begin a new transaction. This will potentially use a transaction
                 // on a different session, while the recommended behavior for a retry is to use the same session as
                 // the original attempt.
                 SpannerTransaction.Dispose();
-                SpannerTransaction = await Connection.SpannerConnection.BeginTransactionAsync(cancellationToken);
+                SpannerTransaction = async
+                    ? await Connection.SpannerConnection.BeginTransactionAsync(cancellationToken)
+                    : Connection.SpannerConnection.BeginTransaction();
                 RetryCount++;
                 try
                 {
                     foreach (IRetriableStatement statement in _retriableStatements)
                     {
-                        await statement.RetryAsync(this, cancellationToken, timeoutSeconds);
+                        if (async)
+                        {
+                            await statement.RetryAsync(this, cancellationToken, timeoutSeconds);
+                        }
+                        else
+                        {
+                            statement.Retry(this, timeoutSeconds);
+                        }
                     }
                     break;
                 }
@@ -456,61 +430,9 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// </summary>
         /// <param name="cancellationToken">A cancellation token used for this task.</param>
         /// <returns>Returns the UTC timestamp when the data was written to the database.</returns>
-        public async Task<DateTime> CommitAndReturnCommitTimestampAsync(CancellationToken cancellationToken = default)
+        public Task<DateTime> CommitAndReturnCommitTimestampAsync(CancellationToken cancellationToken = default)
         {
-            var tracer = TracerProviderExtension.GetTracer();
-            using var span = tracer.StartActiveSpan(TracerProviderExtension.SPAN_NAME_COMMIT);
-            while (true)
-            {
-                try
-                {
-                    _commitTimestamp = await SpannerTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-                    // Propagate the commit timestamp to all columns that were automatically updated during this transaction.
-                    // Note that this transaction could both be a manual transaction started by the application, as well as
-                    // an implicit transaction started by Entity Framework.
-                    foreach (var modificationCommand in _commitTimestampModificationCommands)
-                    {
-                        foreach (var columnModification in modificationCommand.ColumnModifications)
-                        {
-                            if (columnModification is SpannerPendingCommitTimestampColumnModification
-                                pendingCommitTimestampColumnModification)
-                            {
-                                var property = pendingCommitTimestampColumnModification.Property.PropertyInfo;
-                                if (property != null)
-                                {
-                                    var entry = pendingCommitTimestampColumnModification.Entry;
-                                    var originalState = entry.EntityState;
-                                    var entity = entry.ToEntityEntry().Entity;
-                                    property.SetValue(entity, _commitTimestamp);
-                                    entry.EntityState = originalState;
-                                }
-                            }
-                        }
-                    }
-
-                    span.SetStatus(OpenTelemetry.Trace.Status.Ok);
-                    span.End();
-                    return (DateTime)_commitTimestamp;
-                }
-                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
-                {
-                    span.SetAttribute(TracerProviderExtension.ATTRIBUTE_NAME_RETRYING, e.Message);
-                    await RetryAsync(e, cancellationToken).ConfigureAwait(false);
-                }
-                catch (InvalidOperationException e) when (e.Message.Contains("A transaction has not been acquired for this PooledSession because no command execution has been attempted."))
-                {
-                    span.AddEvent("Committed empty transaction, no commit timestamp will be available");
-                    span.SetStatus(OpenTelemetry.Trace.Status.Ok);
-                    span.End();
-                    return DateTime.UnixEpoch;
-                }
-                catch (Exception e)
-                {
-                    span.SetStatus(OpenTelemetry.Trace.Status.Error.WithDescription(e.Message));
-                    span.End();
-                    throw;
-                }
-            }
+            return CommitAndReturnCommitTimestampInternalAsync(async: true, cancellationToken).AsTask();
         }
 
         /// <summary>
@@ -519,14 +441,26 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         /// <returns>Returns the UTC timestamp when the data was written to the database.</returns>
         public DateTime CommitAndReturnCommitTimestamp()
         {
+            return CommitAndReturnCommitTimestampInternalAsync(async: false, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        private async ValueTask<DateTime> CommitAndReturnCommitTimestampInternalAsync(bool async, CancellationToken cancellationToken)
+        {
             var tracer = TracerProviderExtension.GetTracer();
             using var span = tracer.StartActiveSpan(TracerProviderExtension.SPAN_NAME_COMMIT);
             while (true)
             {
                 try
                 {
-                    SpannerTransaction.Commit(out var commitTimestamp);
-                    _commitTimestamp = commitTimestamp;
+                    if (async)
+                    {
+                        _commitTimestamp = await SpannerTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        SpannerTransaction.Commit(out var commitTimestamp);
+                        _commitTimestamp = commitTimestamp;
+                    }
                     // Propagate the commit timestamp to all columns that were automatically updated during this transaction.
                     // Note that this transaction could both be a manual transaction started by the application, as well as
                     // an implicit transaction started by Entity Framework.
@@ -557,7 +491,14 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
                 catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
                 {
                     span.SetAttribute(TracerProviderExtension.ATTRIBUTE_NAME_RETRYING, e.Message);
-                    Retry(e);
+                    if (async)
+                    {
+                        await RetryAsync(e, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        Retry(e);
+                    }
                 }
                 catch (InvalidOperationException e) when (e.Message.Contains("A transaction has not been acquired for this PooledSession because no command execution has been attempted."))
                 {
@@ -579,6 +520,19 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         public override void Commit()
         {
             CommitAndReturnCommitTimestamp();
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (var statement in _retriableStatements)
+                {
+                    statement.Dispose();
+                }
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRetriableTransaction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using System.Linq;
 using Google.Cloud.EntityFrameworkCore.Spanner.Extensions;
 using Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal;
 using Google.Cloud.Spanner.Data;
@@ -149,7 +150,27 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         public override IsolationLevel IsolationLevel => SpannerTransaction.IsolationLevel;
 
         protected internal override int ExecuteNonQueryWithRetry(SpannerCommand command)
-            => Task.Run(() => ExecuteNonQueryWithRetryAsync(command, CancellationToken.None)).ResultWithUnwrappedExceptions();
+        {
+            while (true)
+            {
+                command.Transaction = SpannerTransaction;
+                try
+                {
+                    int res = command.ExecuteNonQuery();
+                    _retriableStatements.Add(new RetriableDmlStatement(command, res));
+                    return res;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    Retry(e);
+                }
+                catch (SpannerException e)
+                {
+                    _retriableStatements.Add(new FailedDmlStatement(command, e));
+                    throw;
+                }
+            }
+        }
 
         protected internal override async Task<int> ExecuteNonQueryWithRetryAsync(SpannerCommand command, CancellationToken cancellationToken = default)
         {
@@ -175,7 +196,27 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         }
 
         protected internal override IReadOnlyList<long> ExecuteNonQueryWithRetry(SpannerRetriableBatchCommand command)
-            => Task.Run(() => ExecuteNonQueryWithRetryAsync(command, CancellationToken.None)).ResultWithUnwrappedExceptions();
+        {
+            while (true)
+            {
+                var spannerCommand = command.CreateSpannerBatchCommand();
+                try
+                {
+                    IReadOnlyList<long> res = spannerCommand.ExecuteNonQuery().ToList();
+                    _retriableStatements.Add(new RetriableBatchDmlStatement(command, res));
+                    return res;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    Retry(e);
+                }
+                catch (SpannerException e)
+                {
+                    _retriableStatements.Add(new FailedBatchDmlStatement(command, e));
+                    throw;
+                }
+            }
+        }
 
         internal async Task<IReadOnlyList<long>> ExecuteNonQueryWithRetryAsync(SpannerRetriableBatchCommand command, CancellationToken cancellationToken = default)
         {
@@ -201,7 +242,15 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         }
 
         protected internal override object ExecuteScalarWithRetry(SpannerCommand command)
-            => Task.Run(() => ExecuteScalarWithRetryAsync(command, CancellationToken.None)).ResultWithUnwrappedExceptions();
+        {
+            using var reader = ExecuteDbDataReaderWithRetryImpl(command);
+            if (reader.Read())
+            {
+                return reader.GetValue(0);
+            }
+
+            return null;
+        }
 
         internal async Task<object> ExecuteScalarWithRetryAsync(SpannerCommand command, CancellationToken cancellationToken)
         {
@@ -216,11 +265,39 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
 
         /// <inheritdoc/>
         protected internal override DbDataReader ExecuteDbDataReaderWithRetry(SpannerCommand command)
-            => Task.Run(() => ExecuteDbDataReaderWithRetryImplAsync(command, CancellationToken.None)).ResultWithUnwrappedExceptions();
+            => ExecuteDbDataReaderWithRetryImpl(command);
 
         /// <inheritdoc/>
         protected internal override async Task<DbDataReader> ExecuteDbDataReaderWithRetryAsync(SpannerCommand command, CancellationToken cancellationToken)
            => await ExecuteDbDataReaderWithRetryImplAsync(command, cancellationToken);
+
+        private SpannerDataReaderWithChecksum ExecuteDbDataReaderWithRetryImpl(SpannerCommand command)
+        {
+            while (true)
+            {
+                command.Transaction = SpannerTransaction;
+                try
+                {
+                    var spannerReader = (SpannerDataReader)command.ExecuteReader();
+                    var checksumReader = new SpannerDataReaderWithChecksum(this, spannerReader, command);
+                    _retriableStatements.Add(checksumReader);
+                    return checksumReader;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    Retry(e);
+                }
+                catch (SpannerException e)
+                {
+                    // We can use a FailedDmlStatement here, as reaching here means that the statement
+                    // failed directly when trying to execute a reader. That indicates that the underlying
+                    // statement was a DML statement with a THEN RETURN clause, and that all we need to
+                    // verify during the retry is that it returns the exact same error when it is executed.
+                    _retriableStatements.Add(new FailedDmlStatement(command, e));
+                    throw;
+                }
+            }
+        }
 
         private async Task<SpannerDataReaderWithChecksum> ExecuteDbDataReaderWithRetryImplAsync(SpannerCommand command, CancellationToken cancellationToken)
         {
@@ -251,7 +328,57 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
         }
 
         internal void Retry(SpannerException abortedException, int timeoutSeconds = MAX_TIMEOUT_SECONDS)
-            => RetryAsync(abortedException, CancellationToken.None, timeoutSeconds).WaitWithUnwrappedExceptions();
+        {
+            if (!EnableInternalRetries)
+            {
+                throw abortedException;
+            }
+            DateTime? overallDeadline = _options.CalculateDeadline(_clock);
+            TimeSpan retryDelay = _options.InitialDelay;
+            // If there's a recommended retry delay specified on the exception
+            // we should respect it.
+            retryDelay = abortedException.RecommendedRetryDelay ?? _options.Jitter(retryDelay);
+            while (true)
+            {
+                if (RetryCount >= MaxInternalRetryCount)
+                {
+                    throw new SpannerException(ErrorCode.Aborted, "Transaction was aborted because it aborted and retried too many times");
+                }
+
+                DateTime expectedRetryTime = _clock.GetCurrentDateTimeUtc() + retryDelay;
+                if (expectedRetryTime > overallDeadline)
+                {
+                    throw new SpannerException(ErrorCode.Aborted, "Transaction was aborted because it timed out while retrying");
+                }
+                _scheduler.Delay(retryDelay, CancellationToken.None).Wait();
+
+                // TODO: Preferably the Spanner client library should have some 'reset' option on an existing
+                // transaction instead of having to begin a new transaction. This will potentially use a transaction
+                // on a different session, while the recommended behavior for a retry is to use the same session as
+                // the original attempt.
+                SpannerTransaction.Dispose();
+                SpannerTransaction = Connection.SpannerConnection.BeginTransaction();
+                RetryCount++;
+                try
+                {
+                    foreach (IRetriableStatement statement in _retriableStatements)
+                    {
+                        statement.Retry(this, timeoutSeconds);
+                    }
+                    break;
+                }
+                catch (SpannerAbortedDueToConcurrentModificationException)
+                {
+                    // Retry failed because of a concurrent modification.
+                    throw;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    // Ignore and retry.
+                    retryDelay = e.RecommendedRetryDelay ?? _options.Jitter(_options.NextDelay(retryDelay));
+                }
+            }
+        }
 
         internal async Task RetryAsync(SpannerException abortedException, CancellationToken cancellationToken, int timeoutSeconds = MAX_TIMEOUT_SECONDS)
         {
@@ -386,7 +513,72 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Storage.Internal
             }
         }
 
+        /// <summary>
+        /// Commits the database transaction synchronously and returns the commit timestamp.
+        /// </summary>
+        /// <returns>Returns the UTC timestamp when the data was written to the database.</returns>
+        public DateTime CommitAndReturnCommitTimestamp()
+        {
+            var tracer = TracerProviderExtension.GetTracer();
+            using var span = tracer.StartActiveSpan(TracerProviderExtension.SPAN_NAME_COMMIT);
+            while (true)
+            {
+                try
+                {
+                    SpannerTransaction.Commit(out var commitTimestamp);
+                    _commitTimestamp = commitTimestamp;
+                    // Propagate the commit timestamp to all columns that were automatically updated during this transaction.
+                    // Note that this transaction could both be a manual transaction started by the application, as well as
+                    // an implicit transaction started by Entity Framework.
+                    foreach (var modificationCommand in _commitTimestampModificationCommands)
+                    {
+                        foreach (var columnModification in modificationCommand.ColumnModifications)
+                        {
+                            if (columnModification is SpannerPendingCommitTimestampColumnModification
+                                pendingCommitTimestampColumnModification)
+                            {
+                                var property = pendingCommitTimestampColumnModification.Property.PropertyInfo;
+                                if (property != null)
+                                {
+                                    var entry = pendingCommitTimestampColumnModification.Entry;
+                                    var originalState = entry.EntityState;
+                                    var entity = entry.ToEntityEntry().Entity;
+                                    property.SetValue(entity, _commitTimestamp);
+                                    entry.EntityState = originalState;
+                                }
+                            }
+                        }
+                    }
+
+                    span.SetStatus(OpenTelemetry.Trace.Status.Ok);
+                    span.End();
+                    return (DateTime)_commitTimestamp;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    span.SetAttribute(TracerProviderExtension.ATTRIBUTE_NAME_RETRYING, e.Message);
+                    Retry(e);
+                }
+                catch (InvalidOperationException e) when (e.Message.Contains("A transaction has not been acquired for this PooledSession because no command execution has been attempted."))
+                {
+                    span.AddEvent("Committed empty transaction, no commit timestamp will be available");
+                    span.SetStatus(OpenTelemetry.Trace.Status.Ok);
+                    span.End();
+                    return DateTime.UnixEpoch;
+                }
+                catch (Exception e)
+                {
+                    span.SetStatus(OpenTelemetry.Trace.Status.Error.WithDescription(e.Message));
+                    span.End();
+                    throw;
+                }
+            }
+        }
+
         /// <inheritdoc />
-        public override void Commit() => CommitAsync(CancellationToken.None).WaitWithUnwrappedExceptions();
+        public override void Commit()
+        {
+            CommitAndReturnCommitTimestamp();
+        }
     }
 }

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch .cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch .cs
@@ -127,7 +127,154 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
         /// </summary>
         public override void Execute(IRelationalConnection connection)
         {
-            Task.Run(() => ExecuteAsync(connection)).WaitWithUnwrappedExceptions();
+            var spannerRelationalConnection = (SpannerRelationalConnection)connection;
+            var spannerConnection = (SpannerRetriableConnection)connection.DbConnection;
+            // There should always be a transaction:
+            // 1. Implicit: A transaction is automatically started by Entity Framework when SaveChanges() is called.
+            // 2. Explicit: The client application has called BeginTransaction() on the database.
+            if (!(connection.CurrentTransaction?.GetDbTransaction() is SpannerRetriableTransaction transaction))
+            {
+                throw new InvalidOperationException("There is no active transaction. Cloud Spanner does not support executing updates without a transaction.");
+            }
+
+            var containsReads = _modificationCommands.Any(c => c.ColumnModifications.Any(cm => cm.IsRead));
+            var useMutations = spannerRelationalConnection.MutationUsage == Infrastructure.MutationUsage.Always
+                || (!_hasExplicitTransaction
+                    && !containsReads
+                    && spannerRelationalConnection.MutationUsage == Infrastructure.MutationUsage.ImplicitTransactions);
+            if (useMutations)
+            {
+                ExecuteMutations(spannerConnection, transaction);
+            }
+            else if (containsReads)
+            {
+                ExecuteDml(connection, spannerConnection, transaction);
+            }
+            else
+            {
+                ExecuteBatchDml(spannerConnection, transaction);
+            }
+        }
+
+        private void ExecuteMutations(
+            SpannerRetriableConnection spannerConnection, SpannerRetriableTransaction transaction)
+        {
+            int index = 0;
+            foreach (var modificationCommand in _modificationCommands)
+            {
+                // We assume that each mutation will affect exactly one row. This assumption always holds for INSERT
+                // and UPDATE mutations (unless they return an error). DELETE mutations could affect zero rows if the
+                // row had already been deleted, and more than one row if the deleted row is in a table with one or
+                // more INTERLEAVED tables that are defined with ON DELETE CASCADE.
+                //
+                // This can be changed if a concurrency token check fails.
+                var updateCount = 1L;
+
+                // Concurrency token checks cannot be included in mutations. Instead, we need to do manual select to check
+                // that the concurrency token is still the same as what we expect. This select is executed in the same
+                // transaction as the mutations, so it is guaranteed that the value that we read here will still be valid
+                // when the mutations are committed.
+                var operations = modificationCommand.ColumnModifications;
+                var hasConcurrencyCondition = operations.Any(o => o.IsCondition && (o.Property?.IsConcurrencyToken ?? false));
+                if (hasConcurrencyCondition)
+                {
+                    var conditionOperations = operations.Where(o => o.IsCondition).ToList();
+                    var concurrencySql = ((SpannerUpdateSqlGenerator)Dependencies.UpdateSqlGenerator).GenerateSelectConcurrencyCheckSql(modificationCommand.TableName, conditionOperations);
+                    var concurrencyCommand = spannerConnection.CreateSelectCommand(concurrencySql);
+                    concurrencyCommand.Transaction = transaction;
+                    foreach (var columnModification in conditionOperations)
+                    {
+                        concurrencyCommand.Parameters.Add(CreateParameter(columnModification, concurrencyCommand, UseValue.Original, false));
+                    }
+                    // Execute the concurrency check query in the read/write transaction and check whether the expected row exists.
+                    using var reader = concurrencyCommand.ExecuteReader();
+                    if (!reader.Read())
+                    {
+                        // Set the update count to 0 to trigger a concurrency exception.
+                        // We do not throw the exception here already, as there might be more concurrency problems,
+                        // and we want to be able to report all in the exception.
+                        updateCount = 0L;
+                    }
+                }
+
+                // Mutation commands must use a specific TIMESTAMP constant for pending commit timestamps instead of the
+                // placeholder string PENDING_COMMIT_TIMESTAMP(). This instructs any pending commit timestamp modifications
+                // to use the mutation constant instead.
+                if (modificationCommand is SpannerPendingCommitTimestampModificationCommand commitTimestampModificationCommand)
+                {
+                    commitTimestampModificationCommand.MarkAsMutationCommand();
+                    transaction.AddSpannerPendingCommitTimestampModificationCommand(commitTimestampModificationCommand);
+                }
+                // Create the mutation command and execute it.
+                var cmd = CreateSpannerMutationCommand(spannerConnection, transaction, modificationCommand);
+                // Note: The following line does not actually execute any command on the backend, it only buffers
+                // the mutation locally to be sent with the next Commit statement.
+                cmd.ExecuteNonQuery();
+                UpdateCounts.Add(updateCount);
+
+                // Check whether we need to generate a SELECT command to propagate computed values back to the context.
+                // This SELECT command will be executed outside of the current implicit transaction.
+                // The propagation query is skipped if the batch uses an explicit transaction, as it will not be able
+                // to read the new value anyways.
+                if (modificationCommand.ColumnModifications.Any(o => o.IsRead) && !_hasExplicitTransaction)
+                {
+                    var keyOperations = operations.Where(o => o.IsKey).ToList();
+                    var readOperations = operations.Where(o => o.IsRead).ToList();
+                    var sql = ((SpannerUpdateSqlGenerator)Dependencies.UpdateSqlGenerator).GenerateSelectAffectedSql(
+                        modificationCommand.TableName, modificationCommand.Schema, readOperations, keyOperations, index);
+                    _propagateResultsCommands.Add(CreateSelectedAffectedCommand(spannerConnection, modificationCommand, sql));
+                }
+                index++;
+            }
+            // Check that there were no concurrency problems detected.
+            if (RowsAffected != _modificationCommands.Count)
+            {
+                ThrowAggregateUpdateConcurrencyException();
+            }
+        }
+
+        private void ExecuteDml(IRelationalConnection connection, SpannerRetriableConnection spannerConnection, SpannerRetriableTransaction transaction)
+        {
+            var commands = CreateSpannerDmlCommands(spannerConnection, transaction);
+            var index = 0;
+            var updateCounts = new List<long>(commands.Count);
+            foreach (var command in commands)
+            {
+                var reader = command.ExecuteReader();
+                var relationalReader = CreateRelationalDataReader(connection, command, reader);
+                var modificationCommand = _modificationCommands[index];
+                var rowsAffected = 0L;
+                while (relationalReader.Read())
+                {
+                    modificationCommand.PropagateResults(relationalReader);
+                    rowsAffected++;
+                }
+                updateCounts.Add(rowsAffected);
+                index++;
+            }
+            UpdateCounts = updateCounts;
+        }
+
+        /// <summary>
+        /// Executes the command batch using DML. DML is less efficient than mutations, but do allow applications
+        /// to read their own writes within a transaction. DML is therefore used by default for explicit transactions.
+        /// Applications can also configure the Spanner Entity Framework provider to use DML for implicit transactions as well.
+        /// </summary>
+        private void ExecuteBatchDml(SpannerRetriableConnection spannerConnection, SpannerRetriableTransaction transaction)
+        {
+            // Create a Batch DML command that contains all the updates in this batch.
+            // The update statements will include any concurrency token checks that might be needed.
+            var cmd = CreateSpannerBatchDmlCommand(spannerConnection, transaction);
+            UpdateCounts = cmd.Item1.ExecuteNonQuery().ToList();
+            if (RowsAffected != _modificationCommands.Count)
+            {
+                ThrowAggregateUpdateConcurrencyException();
+            }
+            // Add any select commands that were generated by the batch for updates that need to propagate results.
+            if (cmd.Item2.Count > 0)
+            {
+                _propagateResultsCommands.AddRange(cmd.Item2);
+            }
         }
 
         /// <summary>

--- a/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch .cs
+++ b/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch .cs
@@ -180,7 +180,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
                 {
                     var conditionOperations = operations.Where(o => o.IsCondition).ToList();
                     var concurrencySql = ((SpannerUpdateSqlGenerator)Dependencies.UpdateSqlGenerator).GenerateSelectConcurrencyCheckSql(modificationCommand.TableName, conditionOperations);
-                    var concurrencyCommand = spannerConnection.CreateSelectCommand(concurrencySql);
+                    using var concurrencyCommand = spannerConnection.CreateSelectCommand(concurrencySql);
                     concurrencyCommand.Transaction = transaction;
                     foreach (var columnModification in conditionOperations)
                     {
@@ -206,7 +206,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
                     transaction.AddSpannerPendingCommitTimestampModificationCommand(commitTimestampModificationCommand);
                 }
                 // Create the mutation command and execute it.
-                var cmd = CreateSpannerMutationCommand(spannerConnection, transaction, modificationCommand);
+                using var cmd = CreateSpannerMutationCommand(spannerConnection, transaction, modificationCommand);
                 // Note: The following line does not actually execute any command on the backend, it only buffers
                 // the mutation locally to be sent with the next Commit statement.
                 cmd.ExecuteNonQuery();
@@ -240,16 +240,19 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
             var updateCounts = new List<long>(commands.Count);
             foreach (var command in commands)
             {
-                var reader = command.ExecuteReader();
-                var relationalReader = CreateRelationalDataReader(connection, command, reader);
-                var modificationCommand = _modificationCommands[index];
-                var rowsAffected = 0L;
-                while (relationalReader.Read())
+                using (command)
                 {
-                    modificationCommand.PropagateResults(relationalReader);
-                    rowsAffected++;
+                    using var reader = command.ExecuteReader();
+                    var relationalReader = CreateRelationalDataReader(connection, command, reader);
+                    var modificationCommand = _modificationCommands[index];
+                    var rowsAffected = 0L;
+                    while (relationalReader.Read())
+                    {
+                        modificationCommand.PropagateResults(relationalReader);
+                        rowsAffected++;
+                    }
+                    updateCounts.Add(rowsAffected);
                 }
-                updateCounts.Add(rowsAffected);
                 index++;
             }
             UpdateCounts = updateCounts;
@@ -341,7 +344,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
                 {
                     var conditionOperations = operations.Where(o => o.IsCondition).ToList();
                     var concurrencySql = ((SpannerUpdateSqlGenerator)Dependencies.UpdateSqlGenerator).GenerateSelectConcurrencyCheckSql(modificationCommand.TableName, conditionOperations);
-                    var concurrencyCommand = spannerConnection.CreateSelectCommand(concurrencySql);
+                    using var concurrencyCommand = spannerConnection.CreateSelectCommand(concurrencySql);
                     concurrencyCommand.Transaction = transaction;
                     foreach (var columnModification in conditionOperations)
                     {
@@ -367,7 +370,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
                     transaction.AddSpannerPendingCommitTimestampModificationCommand(commitTimestampModificationCommand);
                 }
                 // Create the mutation command and execute it.
-                var cmd = CreateSpannerMutationCommand(spannerConnection, transaction, modificationCommand);
+                using var cmd = CreateSpannerMutationCommand(spannerConnection, transaction, modificationCommand);
                 // Note: The following line does not actually execute any command on the backend, it only buffers
                 // the mutation locally to be sent with the next Commit statement.
                 await cmd.ExecuteNonQueryAsync(cancellationToken);
@@ -401,16 +404,19 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
             var updateCounts = new List<long>(commands.Count);
             foreach (var command in commands)
             {
-                var reader = await command.ExecuteReaderAsync(cancellationToken);
-                var relationalReader = CreateRelationalDataReader(connection, command, reader);
-                var modificationCommand = _modificationCommands[index];
-                var rowsAffected = 0L;
-                while (await relationalReader.ReadAsync(cancellationToken))
+                using (command)
                 {
-                    modificationCommand.PropagateResults(relationalReader);
-                    rowsAffected++;
+                    using var reader = await command.ExecuteReaderAsync(cancellationToken);
+                    var relationalReader = CreateRelationalDataReader(connection, command, reader);
+                    var modificationCommand = _modificationCommands[index];
+                    var rowsAffected = 0L;
+                    while (await relationalReader.ReadAsync(cancellationToken))
+                    {
+                        modificationCommand.PropagateResults(relationalReader);
+                        rowsAffected++;
+                    }
+                    updateCounts.Add(rowsAffected);
                 }
-                updateCounts.Add(rowsAffected);
                 index++;
             }
             UpdateCounts = updateCounts;
@@ -461,11 +467,7 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
 
         internal void PropagateResults(IRelationalConnection connection)
         {
-            if (_propagateResultsCommands.Count == 0)
-            {
-                return;
-            }
-            Task.Run(() => PropagateResultsAsync(connection)).WaitWithUnwrappedExceptions();
+            PropagateResultsInternalAsync(connection, async: false, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -479,6 +481,11 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
         /// </summary>
         internal async Task PropagateResultsAsync(IRelationalConnection connection, CancellationToken cancellationToken = default)
         {
+            await PropagateResultsInternalAsync(connection, async: true, cancellationToken);
+        }
+
+        private async ValueTask PropagateResultsInternalAsync(IRelationalConnection connection, bool async, CancellationToken cancellationToken)
+        {
             if (_propagateResultsCommands.Count == 0)
             {
                 return;
@@ -489,11 +496,23 @@ namespace Google.Cloud.EntityFrameworkCore.Spanner.Update.Internal
                 if (modificationCommand.ColumnModifications.Any(m => m.IsRead))
                 {
                     var cmd = _propagateResultsCommands[index];
-                    using var reader = await _propagateResultsCommands[index].ExecuteReaderAsync(cancellationToken);
-                    var relationalReader = CreateRelationalDataReader(connection, cmd, reader);
-                    while (await relationalReader.ReadAsync(cancellationToken))
+                    var reader = async
+                        ? await cmd.ExecuteReaderAsync(cancellationToken)
+                        : cmd.ExecuteReader();
+                    using (reader)
                     {
-                        modificationCommand.PropagateResults(relationalReader);
+                        var relationalReader = CreateRelationalDataReader(connection, cmd, reader);
+                        var hasRow = true;
+                        while (hasRow)
+                        {
+                            hasRow = async
+                                ? await relationalReader.ReadAsync(cancellationToken)
+                                : relationalReader.Read();
+                            if (hasRow)
+                            {
+                                modificationCommand.PropagateResults(relationalReader);
+                            }
+                        }
                     }
                     index++;
                 }


### PR DESCRIPTION
Use native sync methods when executing a transaction retry from a sync database method. The previous implementation used a sync-over-async strategy, that could cause thread pool starvation.
